### PR TITLE
perf(tron): remove parse bridger address

### DIFF
--- a/x/tron/keeper/msg_server_test.go
+++ b/x/tron/keeper/msg_server_test.go
@@ -20,15 +20,6 @@ func (suite *KeeperTestSuite) Test_msgServer_ConfirmBatch() {
 		expPass  bool
 	}{
 		{
-			name: "bridger address",
-			malleate: func() {
-				msg = &crosschaintypes.MsgConfirmBatch{
-					BridgerAddress: helpers.GenerateAddress().Hex(),
-				}
-			},
-			expPass: false,
-		},
-		{
 			name: "couldn't find batch",
 			malleate: func() {
 				msg = &crosschaintypes.MsgConfirmBatch{
@@ -110,15 +101,6 @@ func (suite *KeeperTestSuite) Test_msgServer_OracleSetConfirm() {
 		malleate func()
 		expPass  bool
 	}{
-		{
-			name: "bridger address",
-			malleate: func() {
-				msg = &crosschaintypes.MsgOracleSetConfirm{
-					BridgerAddress: helpers.GenerateAddress().Hex(),
-				}
-			},
-			expPass: false,
-		},
 		{
 			name: "couldn't find oracleSet",
 			malleate: func() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved efficiency by directly using bridger addresses in transaction confirmations, eliminating unnecessary data conversions.
- **Tests**
	- Removed obsolete test cases related to bridger address settings in transaction confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->