### PR TITLE
perf: same address not transfer

### DIFF
--- a/x/crosschain/keeper/bridge_call_in.go
+++ b/x/crosschain/keeper/bridge_call_in.go
@@ -1,6 +1,7 @@
 package keeper
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 
@@ -141,6 +142,9 @@ func (k Keeper) bridgeCallTransferToSender(ctx sdk.Context, receiver sdk.AccAddr
 func (k Keeper) bridgeCallTransferToReceiver(ctx sdk.Context, sender sdk.AccAddress, receiver []byte, coins sdk.Coins) error {
 	for _, coin := range coins {
 		if coin.Denom == fxtypes.DefaultDenom {
+			if bytes.Equal(sender, receiver) {
+				continue
+			}
 			if err := k.bankKeeper.SendCoins(ctx, sender, receiver, sdk.NewCoins(coin)); err != nil {
 				return err
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced security in coin transfer by ensuring sender and receiver addresses are distinct before processing transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->