### PR TITLE
refactor: EmitEvent is used for a single event

### DIFF
--- a/x/crosschain/keeper/bridge_call_in.go
+++ b/x/crosschain/keeper/bridge_call_in.go
@@ -88,7 +88,7 @@ func (k Keeper) BridgeCallEvm(
 			if len(evmErrCause) > 0 {
 				attrs = append(attrs, sdk.NewAttribute(types.AttributeKeyBridgeCallErrCause, evmErrCause))
 			}
-			ctx.EventManager().EmitEvents(sdk.Events{sdk.NewEvent(types.EventTypeBridgeCallEvent, attrs...)})
+			ctx.EventManager().EmitEvent(sdk.NewEvent(types.EventTypeBridgeCallEvent, attrs...))
 		}()
 		gasLimit := k.GetParams(ctx).BridgeCallMaxGasLimit
 		txResp, err := k.evmKeeper.CallEVM(ctx, sender, to, value.BigInt(), gasLimit, data, true)

--- a/x/crosschain/keeper/msg_server.go
+++ b/x/crosschain/keeper/msg_server.go
@@ -167,13 +167,13 @@ func (s MsgServer) AddDelegate(c context.Context, msg *types.MsgAddDelegate) (*t
 	s.SetOracle(ctx, oracle)
 	s.CommonSetOracleTotalPower(ctx)
 
-	ctx.EventManager().EmitEvents(sdk.Events{
+	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, msg.ChainName),
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.OracleAddress),
 		),
-	})
+	)
 
 	return &types.MsgAddDelegateResponse{}, nil
 }

--- a/x/evm/precompiles/staking/transfer_shares.go
+++ b/x/evm/precompiles/staking/transfer_shares.go
@@ -35,13 +35,13 @@ func (c *Contract) TransferShares(ctx sdk.Context, evm *vm.EVM, contract *vm.Con
 		return nil, err
 	}
 
-	ctx.EventManager().EmitEvents(sdk.Events{
+	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, evmtypes.ModuleName),
 			sdk.NewAttribute(sdk.AttributeKeySender, sdk.AccAddress(contract.Caller().Bytes()).String()),
 		),
-	})
+	)
 	return TransferSharesMethod.Outputs.Pack(token, reward)
 }
 
@@ -65,13 +65,13 @@ func (c *Contract) TransferFromShares(ctx sdk.Context, evm *vm.EVM, contract *vm
 		return nil, err
 	}
 
-	ctx.EventManager().EmitEvents(sdk.Events{
+	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, evmtypes.ModuleName),
 			sdk.NewAttribute(sdk.AttributeKeySender, sdk.AccAddress(contract.Caller().Bytes()).String()),
 		),
-	})
+	)
 	return TransferFromSharesMethod.Outputs.Pack(token, reward)
 }
 
@@ -219,7 +219,7 @@ func TransferSharesEmitEvents(ctx sdk.Context, validator sdk.ValAddress, from, r
 		}()
 	}
 
-	ctx.EventManager().EmitEvents(sdk.Events{
+	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			fxstakingtypes.EventTypeTransferShares,
 			sdk.NewAttribute(stakingtypes.AttributeKeyValidator, validator.String()),
@@ -228,5 +228,5 @@ func TransferSharesEmitEvents(ctx sdk.Context, validator sdk.ValAddress, from, r
 			sdk.NewAttribute(fxstakingtypes.AttributeKeyShares, shares.String()),
 			sdk.NewAttribute(fxstakingtypes.AttributeKeyAmount, token.String()),
 		),
-	})
+	)
 }

--- a/x/ibc/applications/transfer/keeper/ibc_call.go
+++ b/x/ibc/applications/transfer/keeper/ibc_call.go
@@ -42,7 +42,7 @@ func (k Keeper) HandlerIbcCallEvm(ctx sdk.Context, sender common.Address, evmPac
 		if len(evmErrCause) > 0 {
 			attrs = append(attrs, sdk.NewAttribute(types.AttributeKeyIBCCallErrCause, evmErrCause))
 		}
-		ctx.EventManager().EmitEvents(sdk.Events{sdk.NewEvent(types.EventTypeIBCCall, attrs...)})
+		ctx.EventManager().EmitEvent(sdk.NewEvent(types.EventTypeIBCCall, attrs...))
 	}()
 	txResp, err := k.evmKeeper.CallEVM(ctx, sender,
 		evmPacket.GetToAddress(), evmPacket.Value.BigInt(), uint64(limit), evmPacket.MustGetData(), true)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected event emission methods to ensure consistent and accurate event logging across various functionalities, including bridge calls, delegate additions, share transfers, and IBC calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->