### PR TITLE
perf(evm): update max-tx-gas-wanted to 0

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -52,6 +52,9 @@ func updateConfig(cmd *cobra.Command, _ []string) error {
 	if err := serverCtx.Viper.Unmarshal(appConfig); err != nil {
 		return err
 	}
+
+	appConfig.EVM.MaxTxGasWanted = 0
+
 	fileName = filepath.Join(rootDir, "config", appFileName)
 	config.WriteConfigFile(fileName, appConfig)
 	serverCtx.Logger.Info("Update app.toml is successful", "fileName", fileName)

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -99,7 +99,7 @@ func TestPublicAppConfig(t *testing.T) {
 	appConfig.Telemetry.PrometheusRetentionTime = 60
 	appConfig.API.Enable = true
 	appConfig.API.Swagger = true
-	appConfig.EVM.MaxTxGasWanted = 500000
+	appConfig.EVM.MaxTxGasWanted = 0
 	appConfig.Rosetta.DenomToSuggest = "FX"
 
 	fileName := fmt.Sprintf("%s/app.toml", t.TempDir())

--- a/public/mainnet/app.toml
+++ b/public/mainnet/app.toml
@@ -275,7 +275,7 @@ msg-max-gas-usage = 300000
 tracer = ""
 
 # MaxTxGasWanted defines the gas wanted for each eth tx returned in ante handler in check tx mode.
-max-tx-gas-wanted = 500000
+max-tx-gas-wanted = 0
 
 ###############################################################################
 ###                           JSON RPC Configuration                        ###

--- a/public/testnet/app.toml
+++ b/public/testnet/app.toml
@@ -275,7 +275,7 @@ msg-max-gas-usage = 300000
 tracer = ""
 
 # MaxTxGasWanted defines the gas wanted for each eth tx returned in ante handler in check tx mode.
-max-tx-gas-wanted = 500000
+max-tx-gas-wanted = 0
 
 ###############################################################################
 ###                           JSON RPC Configuration                        ###


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Changes**
  - Updated the `max-tx-gas-wanted` value from `500000` to `0` for both mainnet and testnet configurations. This affects the gas wanted for each Ethereum transaction in check transaction mode.

- **Testing Adjustments**
  - Modified test configurations to reflect the new `max-tx-gas-wanted` value of `0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->