### PR TITLE
build(solidity): upgrade hardhat-verify support baseSepolia

### DIFF
--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -76,6 +76,7 @@ const config: HardhatUserConfig = {
             sepolia: `${process.env.ETHERSCAN_API_KEY}`,
             arbitrumSepolia: `${process.env.ETHERSCAN_API_KEY}`,
             optimisticSepolia: `${process.env.ETHERSCAN_API_KEY}`,
+            baseSepolia: `${process.env.ETHERSCAN_API_KEY}`
         },
         customChains: [
             {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@ethers-ext/signer-ledger": "^6.0.0-beta.1",
     "@ledgerhq/hw-transport-node-hid": "^6.28.1",
-    "@nomicfoundation/hardhat-verify": "^2.0.3",
+    "@nomicfoundation/hardhat-verify": "^2.0.7",
     "@openzeppelin/contracts": "^4.9.6",
     "@openzeppelin/contracts-upgradeable": "4.9.6",
     "@types/chai": "^4.3.9",

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -705,10 +705,10 @@
     debug "^4.1.1"
     lodash.isequal "^4.5.0"
 
-"@nomicfoundation/hardhat-verify@^2.0.3":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.4.tgz#65b86787fc7b47d38fd941862266065c7eb9bca4"
-  integrity sha512-B8ZjhOrmbbRWqJi65jvQblzjsfYktjqj2vmOm+oc2Vu8drZbT2cjeSCRHZKbS7lOtfW78aJZSFvw+zRLCiABJA==
+"@nomicfoundation/hardhat-verify@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.7.tgz#852f754440e177b9c8b61f4f7cec1c26c5eadb8e"
+  integrity sha512-jiYHBX+K6bBN0YhwFHQ5SWWc3dQZliM3pdgpH33C7tnsVACsX1ubZn6gZ9hfwlzG0tyjFM72XQhpaXQ56cE6Ew==
   dependencies:
     "@ethersproject/abi" "^5.1.2"
     "@ethersproject/address" "^5.0.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Etherscan verification with the `baseSepolia` network configuration.

- **Chores**
  - Updated `@nomicfoundation/hardhat-verify` dependency to version `^2.0.7`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->