### PR TITLE
refactor: reanme precoimpile receiver to refund

### DIFF
--- a/x/crosschain/keeper/hook.go
+++ b/x/crosschain/keeper/hook.go
@@ -47,7 +47,7 @@ func (k Keeper) PrecompileIncreaseBridgeFee(ctx sdk.Context, txID uint64, sender
 func (k Keeper) PrecompileBridgeCall(
 	ctx sdk.Context,
 	sender common.Address,
-	receiver common.Address,
+	refund common.Address,
 	coins sdk.Coins,
 	to common.Address,
 	data []byte,
@@ -61,7 +61,7 @@ func (k Keeper) PrecompileBridgeCall(
 	outCall, err := k.AddOutgoingBridgeCall(
 		ctx,
 		sender.Bytes(),
-		types.ExternalAddrToStr(k.moduleName, receiver.Bytes()),
+		types.ExternalAddrToStr(k.moduleName, refund.Bytes()),
 		tokens,
 		types.ExternalAddrToStr(k.moduleName, to.Bytes()),
 		hex.EncodeToString(data),

--- a/x/evm/precompiles/crosschain/bridge_call.go
+++ b/x/evm/precompiles/crosschain/bridge_call.go
@@ -49,7 +49,7 @@ func (c *Contract) BridgeCall(ctx sdk.Context, evm *vm.EVM, contract *vm.Contrac
 	nonce, err := route.PrecompileBridgeCall(
 		ctx,
 		sender,
-		args.Receiver,
+		args.Refund,
 		coins,
 		args.To,
 		args.Data,
@@ -61,7 +61,7 @@ func (c *Contract) BridgeCall(ctx sdk.Context, evm *vm.EVM, contract *vm.Contrac
 
 	nonceNonce := big.NewInt(0).SetUint64(nonce)
 	if err = c.AddLog(evm, BridgeCallEvent,
-		[]common.Hash{sender.Hash(), args.Receiver.Hash(), args.To.Hash()},
+		[]common.Hash{sender.Hash(), args.Refund.Hash(), args.To.Hash()},
 		evm.Origin,
 		args.Value,
 		nonceNonce,

--- a/x/evm/precompiles/crosschain/methods.go
+++ b/x/evm/precompiles/crosschain/methods.go
@@ -1,12 +1,12 @@
 package crosschain
 
 import (
-	"bytes"
 	"errors"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/functionx/fx-core/v7/contract"
 	crosschaintypes "github.com/functionx/fx-core/v7/x/crosschain/types"
 )
 
@@ -136,7 +136,7 @@ func (args *IncreaseBridgeFeeArgs) Validate() error {
 
 type BridgeCallArgs struct {
 	DstChain string           `abi:"_dstChain"`
-	Receiver common.Address   `abi:"_receiver"`
+	Refund   common.Address   `abi:"_refund"`
 	Tokens   []common.Address `abi:"_tokens"`
 	Amounts  []*big.Int       `abi:"_amounts"`
 	To       common.Address   `abi:"_to"`
@@ -156,13 +156,8 @@ func (args *BridgeCallArgs) Validate() error {
 	if len(args.Tokens) != len(args.Amounts) {
 		return errors.New("tokens and amounts do not match")
 	}
-	if len(args.Amounts) > 0 {
-		if bytes.Equal(args.Receiver.Bytes(), common.Address{}.Bytes()) {
-			return errors.New("receiver cannot be empty")
-		}
-	}
-	if len(args.Tokens) == 0 && len(args.Data) == 0 {
-		return errors.New("tokens and data cannot be empty at the same time")
+	if len(args.Amounts) > 0 && contract.IsZeroEthAddress(args.Refund) {
+		return errors.New("refund cannot be empty")
 	}
 	return nil
 }

--- a/x/evm/precompiles/crosschain/router.go
+++ b/x/evm/precompiles/crosschain/router.go
@@ -11,7 +11,7 @@ type Precompile interface {
 	TransferAfter(ctx sdk.Context, sender sdk.AccAddress, receive string, coins, fee sdk.Coin, originToken, insufficientLiquidity bool) error
 	PrecompileCancelSendToExternal(ctx sdk.Context, txID uint64, sender sdk.AccAddress) (sdk.Coin, error)
 	PrecompileIncreaseBridgeFee(ctx sdk.Context, txID uint64, sender sdk.AccAddress, addBridgeFee sdk.Coin) error
-	PrecompileBridgeCall(ctx sdk.Context, sender, receiver common.Address, coins sdk.Coins, to common.Address, data, memo []byte) (uint64, error)
+	PrecompileBridgeCall(ctx sdk.Context, sender, refund common.Address, coins sdk.Coins, to common.Address, data, memo []byte) (uint64, error)
 }
 
 type Router struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed `receiver` parameter to `refund` across cross-chain and EVM precompile modules for consistency and clarity in bridge call processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->