### PR TITLE
chore: use direct docker images name

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,15 +33,15 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
-            ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}
+            ghcr.io/functionx/fx-core
+            functionx/fx-core
           tags: |
             type=semver,pattern={{version}}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          username: functionx
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to Container registry
@@ -76,15 +76,15 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/fxcorevisor_lite
-            ${{ secrets.DOCKER_HUB_USERNAME }}/fxcorevisor_lite
+            ghcr.io/functionx/fxcorevisor-lite
+            functionx/fxcorevisor-lite
           tags: |
             type=semver,pattern={{version}}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          username: functionx
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to Container registry
@@ -120,15 +120,15 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/fxcorevisor
-            ${{ secrets.DOCKER_HUB_USERNAME }}/fxcorevisor
+            ghcr.io/functionx/fxcorevisor
+            functionx/fxcorevisor
           tags: |
             type=semver,pattern={{version}}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          username: functionx
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to Container registry

--- a/cosmovisor.Dockerfile
+++ b/cosmovisor.Dockerfile
@@ -38,9 +38,6 @@ ENV DAEMON_PREUPGRADE_MAX_RETRIES=3
 ENV COSMOVISOR_DISABLE_LOGS=false
 ENV COSMOVISOR_COLOR_LOGS=true
 
-COPY --from=builder /go/bin/cosmovisor /usr/bin/cosmovisor
-COPY --from=builder /app/build/bin/fxcored /usr/bin/fxcored
-
 # The copy directory needs to be changed in the next version
 COPY --from=fxv1 /usr/bin/fxcored /root/.fxcore/cosmovisor/genesis/bin/fxcored
 COPY --from=fxv2 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/fxv2/bin/fxcored
@@ -53,6 +50,10 @@ COPY --from=fxv6 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v6.0.x/bin/f
 COPY --from=fxv7 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v7.0.x/bin/fxcored
 COPY --from=fxv7_1 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v7.1.x/bin/fxcored
 COPY --from=fxv7_2 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v7.2.x/bin/fxcored
+
+COPY --from=builder /go/bin/cosmovisor /usr/bin/cosmovisor
+COPY --from=builder /app/build/bin/fxcored /usr/bin/fxcored
+COPY --from=builder /app/build/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v7.3.x/bin/fxcored
 
 RUN cosmovisor init /root/.fxcore/cosmovisor/genesis/bin/fxcored
 

--- a/cosmovisor_lite.Dockerfile
+++ b/cosmovisor_lite.Dockerfile
@@ -31,13 +31,14 @@ ENV DAEMON_PREUPGRADE_MAX_RETRIES=3
 ENV COSMOVISOR_DISABLE_LOGS=false
 ENV COSMOVISOR_COLOR_LOGS=true
 
-COPY --from=builder /go/bin/cosmovisor /usr/bin/cosmovisor
-COPY --from=builder /app/build/bin/fxcored /usr/bin/fxcored
-
 COPY --from=fxv6 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v6.0.x/bin/fxcored
 COPY --from=fxv7 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v7.0.x/bin/fxcored
 COPY --from=fxv7_1 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v7.1.x/bin/fxcored
 COPY --from=fxv7_2 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v7.2.x/bin/fxcored
+
+COPY --from=builder /go/bin/cosmovisor /usr/bin/cosmovisor
+COPY --from=builder /app/build/bin/fxcored /usr/bin/fxcored
+COPY --from=builder /app/build/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v7.3.x/bin/fxcored
 
 RUN cosmovisor init /root/.fxcore/cosmovisor/upgrades/v6.0.x/bin/fxcored
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker image references and login credentials for improved security and consistency.
  - Adjusted copy instructions in Dockerfiles to support new binary versions and ensure proper initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->