### PR TITLE
fix: init bridge call from account

### DIFF
--- a/app/upgrades/v7/upgrade.go
+++ b/app/upgrades/v7/upgrade.go
@@ -5,6 +5,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	autytypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
 	"github.com/functionx/fx-core/v7/app/keepers"
@@ -30,6 +31,10 @@ func CreateUpgradeHandler(mm *module.Manager, configurator module.Configurator, 
 		UpdateFIP20LogicCode(cacheCtx, app.EvmKeeper)
 		CleanCrosschainAttestations(ctx, app.AppCodec(), app.GetKey(ethtypes.ModuleName))
 		CleanCrosschainAttestations(ctx, app.AppCodec(), app.GetKey(layer2types.ModuleName))
+		crosschainBridgeCallFrom := autytypes.NewModuleAddress(crosschaintypes.ModuleName)
+		if account := app.AccountKeeper.GetAccount(ctx, crosschainBridgeCallFrom); account == nil {
+			app.AccountKeeper.SetAccount(ctx, app.AccountKeeper.NewAccountWithAddress(ctx, crosschainBridgeCallFrom))
+		}
 
 		commit()
 		ctx.Logger().Info("upgrade complete", "module", "upgrade")

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -177,7 +177,7 @@ func (suite *rpcTestSuite) TestClient_Tx() {
 
 		account, err := cli.QueryAccount(toAddress.String())
 		suite.NoError(err)
-		suite.Equal(authtypes.NewBaseAccount(toAddress, nil, uint64(13+i), 0), account)
+		suite.Equal(authtypes.NewBaseAccount(toAddress, nil, uint64(14+i), 0), account)
 	}
 
 	ethPrivKey := suite.GetPrivKeyByIndex(hd2.EthSecp256k1Type, 0)
@@ -210,7 +210,7 @@ func (suite *rpcTestSuite) TestClient_Tx() {
 
 		account, err := cli.QueryAccount(ethAddress.String())
 		suite.NoError(err)
-		suite.Equal(authtypes.NewBaseAccount(ethAddress, nil, uint64(16), 0), account)
+		suite.Equal(authtypes.NewBaseAccount(ethAddress, nil, uint64(17), 0), account)
 	}
 
 	for i := 0; i < len(clients); i++ {

--- a/x/crosschain/keeper/genesis.go
+++ b/x/crosschain/keeper/genesis.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	autytypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/functionx/fx-core/v7/x/crosschain/types"
 )
@@ -12,6 +13,10 @@ import (
 func InitGenesis(ctx sdk.Context, k Keeper, state *types.GenesisState) {
 	if err := k.SetParams(ctx, &state.Params); err != nil {
 		panic(err)
+	}
+	crosschainBridgeCallFrom := autytypes.NewModuleAddress(types.ModuleName)
+	if account := k.ak.GetAccount(ctx, crosschainBridgeCallFrom); account == nil {
+		k.ak.SetAccount(ctx, k.ak.NewAccountWithAddress(ctx, crosschainBridgeCallFrom))
 	}
 
 	// 0x24

--- a/x/crosschain/mock/expected_keepers_mocks.go
+++ b/x/crosschain/mock/expected_keepers_mocks.go
@@ -786,6 +786,18 @@ func (mr *MockAccountKeeperMockRecorder) NewAccountWithAddress(ctx, addr any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAccountWithAddress", reflect.TypeOf((*MockAccountKeeper)(nil).NewAccountWithAddress), ctx, addr)
 }
 
+// SetAccount mocks base method.
+func (m *MockAccountKeeper) SetAccount(ctx types.Context, acc types0.AccountI) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetAccount", ctx, acc)
+}
+
+// SetAccount indicates an expected call of SetAccount.
+func (mr *MockAccountKeeperMockRecorder) SetAccount(ctx, acc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAccount", reflect.TypeOf((*MockAccountKeeper)(nil).SetAccount), ctx, acc)
+}
+
 // MockSubspace is a mock of Subspace interface.
 type MockSubspace struct {
 	ctrl     *gomock.Controller

--- a/x/crosschain/types/expected_keepers.go
+++ b/x/crosschain/types/expected_keepers.go
@@ -86,6 +86,7 @@ type IBCTransferKeeper interface {
 type AccountKeeper interface {
 	GetModuleAddress(name string) sdk.AccAddress
 	GetAccount(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
+	SetAccount(ctx sdk.Context, acc authtypes.AccountI)
 	NewAccountWithAddress(ctx sdk.Context, addr sdk.AccAddress) authtypes.AccountI
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced cross-chain bridge call handling with automatic account creation if the account does not exist.
  - Added account management capabilities to support cross-chain functionalities.

- **Tests**
  - Updated test cases to reflect new account management logic.

- **Mocking**
  - Enhanced mocking capabilities with a new `SetAccount` method in `MockAccountKeeper`.

- **Refactor**
  - Added new methods to interfaces and mock structures to support the new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->