### PR TITLE
refactor: use clientContext.PrintRaw replace PrintOutput

### DIFF
--- a/client/cli/block_result.go
+++ b/client/cli/block_result.go
@@ -53,7 +53,11 @@ func QueryBlockResultsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return PrintOutput(clientCtx, output)
+			raw, err := json.Marshal(output)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintRaw(raw)
 		},
 	}
 	flags.AddQueryFlagsToCmd(cmd)

--- a/client/cli/debug.go
+++ b/client/cli/debug.go
@@ -366,11 +366,15 @@ func AddrCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return PrintOutput(clientCtx, map[string]interface{}{
+			raw, err := json.Marshal(map[string]interface{}{
 				"base64": addr,
 				"hex":    hex.EncodeToString(addr),
 				"bech32": convertedAddress,
 			})
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintRaw(raw)
 		},
 	}
 	cmd.Flags().StringP("prefix", "p", "fx", "Bech32 Prefix to encode to")

--- a/client/cli/gentx.go
+++ b/client/cli/gentx.go
@@ -31,8 +31,6 @@ import (
 	"github.com/spf13/cobra"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	tmtypes "github.com/tendermint/tendermint/types"
-
-	fxstakingtypes "github.com/functionx/fx-core/v7/x/staking/types"
 )
 
 // GenTxCmd builds the application's gentx command.
@@ -335,7 +333,7 @@ func ValidateAccountInGenesis(
 	appGenesisState map[string]json.RawMessage, genBalIterator types.GenesisBalancesIterator,
 	addr sdk.Address, coins sdk.Coins, cdc codec.JSONCodec,
 ) error {
-	var stakingData fxstakingtypes.GenesisState
+	var stakingData stakingtypes.GenesisState
 	cdc.MustUnmarshalJSON(appGenesisState[stakingtypes.ModuleName], &stakingData)
 	bondDenom := stakingData.Params.BondDenom
 

--- a/client/cli/keys/parse.go
+++ b/client/cli/keys/parse.go
@@ -2,6 +2,7 @@ package keys
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -11,8 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/evmos/ethermint/crypto/ethsecp256k1"
 	"github.com/spf13/cobra"
-
-	"github.com/functionx/fx-core/v7/client/cli"
 )
 
 const prefixFlag = "prefix"
@@ -85,7 +84,11 @@ func ParseAddressCommand() *cobra.Command {
 				}
 			}
 
-			return cli.PrintOutput(clientCtx, outputMap)
+			raw, err := json.Marshal(outputMap)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintRaw(raw)
 		},
 	}
 	cmd.Flags().String(prefixFlag, "fx", "custom address prefix")

--- a/client/cli/node.go
+++ b/client/cli/node.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -54,10 +55,14 @@ func QueryStoreCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return PrintOutput(clientCtx, map[string]interface{}{
+			raw, err := json.Marshal(map[string]interface{}{
 				"block_height": height,
 				"data":         hex.EncodeToString(data),
 			})
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintRaw(raw)
 		},
 	}
 	flags.AddQueryFlagsToCmd(cmd)

--- a/client/cli/query_tx.go
+++ b/client/cli/query_tx.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -87,7 +88,7 @@ $ %s query txs --%s 'message.sender=fx1...&message.module=distribution' --page 1
 			for i := 0; i < len(txsResult.Txs); i++ {
 				txsArray = append(txsArray, TxResponseToMap(clientCtx.Codec, txsResult.Txs[i]))
 			}
-			return PrintOutput(clientCtx, map[string]interface{}{
+			raw, err := json.Marshal(map[string]interface{}{
 				"total_count": txsResult.TotalCount,
 				"count":       txsResult.Count,
 				"page_number": txsResult.PageNumber,
@@ -95,6 +96,10 @@ $ %s query txs --%s 'message.sender=fx1...&message.module=distribution' --page 1
 				"limit":       txsResult.Limit,
 				"txs":         txsArray,
 			})
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintRaw(raw)
 		},
 	}
 
@@ -154,7 +159,11 @@ $ %s query tx --%s=%s <sig1_base64>,<sig2_base64...>
 								// This case means there's a bug somewhere else in the code. Should not happen.
 								return fmt.Errorf("found %d txs matching given ethereum tx hash", len(txs.Txs))
 							}
-							return PrintOutput(clientCtx, TxResponseToMap(clientCtx.Codec, txs.Txs[0]))
+							raw, err := json.Marshal(TxResponseToMap(clientCtx.Codec, txs.Txs[0]))
+							if err != nil {
+								return err
+							}
+							return clientCtx.PrintRaw(raw)
 						}
 						return err
 					}
@@ -162,7 +171,11 @@ $ %s query tx --%s=%s <sig1_base64>,<sig2_base64...>
 					if resp.Empty() {
 						return fmt.Errorf("no transaction found with hash %s", txHash)
 					}
-					return PrintOutput(clientCtx, TxResponseToMap(clientCtx.Codec, resp))
+					raw, err := json.Marshal(TxResponseToMap(clientCtx.Codec, resp))
+					if err != nil {
+						return err
+					}
+					return clientCtx.PrintRaw(raw)
 				}
 			case typeSig:
 				{
@@ -186,7 +199,11 @@ $ %s query tx --%s=%s <sig1_base64>,<sig2_base64...>
 						// This case means there's a bug somewhere else in the code. Should not happen.
 						return fmt.Errorf("found %d txs matching given signatures", len(txs.Txs))
 					}
-					return PrintOutput(clientCtx, TxResponseToMap(clientCtx.Codec, txs.Txs[0]))
+					raw, err := json.Marshal(TxResponseToMap(clientCtx.Codec, txs.Txs[0]))
+					if err != nil {
+						return err
+					}
+					return clientCtx.PrintRaw(raw)
 				}
 			case typeAccSeq:
 				{
@@ -208,8 +225,11 @@ $ %s query tx --%s=%s <sig1_base64>,<sig2_base64...>
 						// This case means there's a bug somewhere else in the code. Should not happen.
 						return fmt.Errorf("found %d txs matching given address and sequence combination", len(txs.Txs))
 					}
-
-					return PrintOutput(clientCtx, TxResponseToMap(clientCtx.Codec, txs.Txs[0]))
+					raw, err := json.Marshal(TxResponseToMap(clientCtx.Codec, txs.Txs[0]))
+					if err != nil {
+						return err
+					}
+					return clientCtx.PrintRaw(raw)
 				}
 			default:
 				return fmt.Errorf("unknown --%s value %s", flagType, typ)

--- a/client/cli/status.go
+++ b/client/cli/status.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"time"
 
@@ -89,7 +90,11 @@ func StatusCommand() *cobra.Command {
 					VotingPower: status.ValidatorInfo.VotingPower,
 				},
 			}
-			return PrintOutput(clientCtx, statusWithPk)
+			raw, err := json.Marshal(statusWithPk)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintRaw(raw)
 		},
 	}
 

--- a/server/config/config_cmd.go
+++ b/server/config/config_cmd.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -12,8 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	tmcfg "github.com/tendermint/tendermint/config"
-
-	"github.com/functionx/fx-core/v7/client/cli"
 )
 
 func CmdHandler(cmd *cobra.Command, args []string) error {
@@ -133,10 +132,18 @@ func output(ctx client.Context, content interface{}) error {
 	var mapData map[string]interface{}
 	if err := mapstructure.Decode(content, &mapData); err != nil {
 		var data interface{}
-		if err := mapstructure.Decode(content, &data); err != nil {
+		if err = mapstructure.Decode(content, &data); err != nil {
 			return err
 		}
-		return cli.PrintOutput(ctx, data)
+		raw, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+		return ctx.PrintRaw(raw)
 	}
-	return cli.PrintOutput(ctx, mapData)
+	raw, err := json.Marshal(mapData)
+	if err != nil {
+		return err
+	}
+	return ctx.PrintRaw(raw)
 }

--- a/server/config/config_cmd_test.go
+++ b/server/config/config_cmd_test.go
@@ -200,7 +200,7 @@ func Test_configTomlConfig_output(t *testing.T) {
 		OutputFormat: "json",
 	}
 	assert.NoError(t, c.output(clientCtx))
-	assert.Equal(t, tmConfigJson, buf.String())
+	assert.JSONEq(t, tmConfigJson, buf.String())
 }
 
 func Test_appTomlConfig_output(t *testing.T) {
@@ -326,5 +326,5 @@ func Test_appTomlConfig_output(t *testing.T) {
 		OutputFormat: "json",
 	}
 	assert.NoError(t, c.output(clientCtx))
-	assert.Equal(t, appConfigJson, buf.String())
+	assert.JSONEq(t, appConfigJson, buf.String())
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved JSON handling across multiple CLI commands by integrating direct JSON marshaling and printing.
  - Enhanced error handling in the `AddrCmd` function for better reliability.

- **Bug Fixes**
  - Ensured consistent JSON output formatting in various CLI commands, improving data readability and accuracy.

- **Tests**
  - Updated test functions to use `assert.JSONEq` for more accurate JSON string comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->