### PR TITLE
fix: delete bridge call address and nonce key

### DIFF
--- a/x/crosschain/keeper/bridge_call_out.go
+++ b/x/crosschain/keeper/bridge_call_out.go
@@ -114,6 +114,14 @@ func (k Keeper) SetOutgoingBridgeCall(ctx sdk.Context, outCall *types.OutgoingBr
 	)
 }
 
+func (k Keeper) HasOutgoingBridgeCall(ctx sdk.Context, nonce uint64) bool {
+	return ctx.KVStore(k.storeKey).Has(types.GetOutgoingBridgeCallNonceKey(nonce))
+}
+
+func (k Keeper) HasOutgoingBridgeCallAddressAndNonce(ctx sdk.Context, sender string, nonce uint64) bool {
+	return ctx.KVStore(k.storeKey).Has(types.GetOutgoingBridgeCallAddressAndNonceKey(sender, nonce))
+}
+
 func (k Keeper) GetOutgoingBridgeCallByNonce(ctx sdk.Context, nonce uint64) (*types.OutgoingBridgeCall, bool) {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(types.GetOutgoingBridgeCallNonceKey(nonce))
@@ -127,7 +135,12 @@ func (k Keeper) GetOutgoingBridgeCallByNonce(ctx sdk.Context, nonce uint64) (*ty
 
 func (k Keeper) DeleteOutgoingBridgeCall(ctx sdk.Context, nonce uint64) {
 	store := ctx.KVStore(k.storeKey)
+	outCall, found := k.GetOutgoingBridgeCallByNonce(ctx, nonce)
+	if !found {
+		return
+	}
 	store.Delete(types.GetOutgoingBridgeCallNonceKey(nonce))
+	store.Delete(types.GetOutgoingBridgeCallAddressAndNonceKey(outCall.Sender, outCall.Nonce))
 }
 
 func (k Keeper) IterateOutgoingBridgeCalls(ctx sdk.Context, cb func(outCall *types.OutgoingBridgeCall) bool) {

--- a/x/crosschain/keeper/bridge_call_out_test.go
+++ b/x/crosschain/keeper/bridge_call_out_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
 	"go.uber.org/mock/gomock"
 
 	"github.com/functionx/fx-core/v7/testutil/helpers"
@@ -147,4 +148,21 @@ func (s *KeeperTestSuite) TestKeeper_BridgeCallCoinsToERC20Token() {
 			}
 		})
 	}
+}
+
+func (s *KeeperTestSuite) TestKeeper_DeleteOutgoingBridgeCall() {
+	outCall := &types.OutgoingBridgeCall{
+		Sender: helpers.GenHexAddress().String(),
+		Nonce:  tmrand.Uint64(),
+	}
+	outCallNonce := s.crosschainKeeper.AddOutgoingBridgeCallWithoutBuild(s.ctx, outCall)
+	s.Require().EqualValues(outCall.Nonce, outCallNonce)
+
+	s.Require().True(s.crosschainKeeper.HasOutgoingBridgeCall(s.ctx, outCall.Nonce))
+	s.Require().True(s.crosschainKeeper.HasOutgoingBridgeCallAddressAndNonce(s.ctx, outCall.Sender, outCall.Nonce))
+
+	s.crosschainKeeper.DeleteOutgoingBridgeCall(s.ctx, outCall.Nonce)
+
+	s.Require().False(s.crosschainKeeper.HasOutgoingBridgeCall(s.ctx, outCall.Nonce))
+	s.Require().False(s.crosschainKeeper.HasOutgoingBridgeCallAddressAndNonce(s.ctx, outCall.Sender, outCall.Nonce))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added ability to verify and delete outgoing bridge calls by sender and nonce.

- **Tests**
  - Introduced a new test to ensure outgoing bridge calls can be deleted and verified properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->