### PR TITLE
chore(deps): bump amannn/action-semantic-pull-request from 5.5.2 to 5.5.3

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -15,7 +15,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.5.2
+      - uses: amannn/action-semantic-pull-request@v5.5.3
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Action `amannn/action-semantic-pull-request` to version `v5.5.3` for improved workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->