### PR TITLE
test: fix test oracle not on line

### DIFF
--- a/tests/crosschain_suite.go
+++ b/tests/crosschain_suite.go
@@ -641,6 +641,8 @@ func (suite *CrosschainTestSuite) BridgeCallConfirm(nonce uint64, isSuccess bool
 			Signature:       hex.EncodeToString(signatureBytes),
 			ChainName:       suite.chainName,
 		},
+	)
+	suite.BroadcastTx(suite.bridgerPrivKey,
 		&crosschaintypes.MsgBridgeCallResultClaim{
 			ChainName:      suite.chainName,
 			BridgerAddress: suite.BridgerAddr().String(),

--- a/tests/crosschain_test.go
+++ b/tests/crosschain_test.go
@@ -291,6 +291,8 @@ func (suite *IntegrationTest) LiquidityTest() {
 	suite.Equal(1, len(unbatchedTx))
 	suite.EqualValues(transferAmount, unbatchedTx[0].Token.Amount.Add(unbatchedTx[0].Fee.Amount))
 	suite.EqualValues(moduleTokenMap[bscChain.chainName], unbatchedTx[0].Token.GetContract())
+	bscChain.CancelAllSendToExternal()
+	suite.Equal(0, len(bscChain.QueryPendingUnbatchedTx(bscChain.AccAddress())))
 }
 
 func (suite *IntegrationTest) BridgeCallTest() {

--- a/tests/suite.go
+++ b/tests/suite.go
@@ -274,6 +274,7 @@ func (suite *TestSuite) BroadcastTx(privKey cryptotypes.PrivKey, msgList ...sdk.
 	txResponse, err := grpcClient.BroadcastTx(txRaw)
 	suite.NoError(err)
 	suite.NotNil(txResponse) // txResponse might be nil, but error is also nil
+	suite.EqualValues(0, txResponse.Code)
 	txResponse, err = grpcClient.WaitMined(txResponse.TxHash, 200*suite.timeoutCommit, 10*suite.timeoutCommit)
 	suite.NoError(err)
 	suite.T().Log("broadcast tx", "msg:", sdk.MsgTypeURL(msgList[0]), "height:", txResponse.Height, "txHash:", txResponse.TxHash)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the `BridgeCallConfirm` method to include transaction broadcasting after confirmation, improving test suite functionality.
	- Added validation in the `BroadcastTx` method to ensure successful transaction responses, increasing test robustness.
- **Tests**
	- Improved the `LiquidityTest` function by clearing pending transactions and validating their state, enhancing test accuracy and control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->