### PR TITLE
feat(crosschain): add oracle_status metrics

### DIFF
--- a/x/crosschain/keeper/msg_server.go
+++ b/x/crosschain/keeper/msg_server.go
@@ -7,6 +7,8 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
+	"github.com/armon/go-metrics"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -161,6 +163,16 @@ func (s MsgServer) AddDelegate(c context.Context, msg *types.MsgAddDelegate) (*t
 	if !oracle.Online {
 		oracle.Online = true
 		oracle.StartHeight = ctx.BlockHeight()
+		if !ctx.IsCheckTx() {
+			telemetry.SetGaugeWithLabels(
+				[]string{types.ModuleName, types.MetricsKeyOracleStatus},
+				float32(0),
+				[]metrics.Label{
+					telemetry.NewLabel(types.MetricsLabelModule, s.moduleName),
+					telemetry.NewLabel(types.MetricsLabelAddress, oracle.OracleAddress),
+				},
+			)
+		}
 	}
 	oracle.SlashTimes = 0
 

--- a/x/crosschain/keeper/oracle.go
+++ b/x/crosschain/keeper/oracle.go
@@ -2,6 +2,8 @@ package keeper
 
 import (
 	sdkmath "cosmossdk.io/math"
+	"github.com/armon/go-metrics"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/functionx/fx-core/v7/x/crosschain/types"
@@ -196,6 +198,16 @@ func (k Keeper) SlashOracle(ctx sdk.Context, oracleAddrStr string) {
 	}
 	if !oracle.Online {
 		return
+	}
+	if !ctx.IsCheckTx() {
+		telemetry.SetGaugeWithLabels(
+			[]string{types.ModuleName, types.MetricsKeyOracleStatus},
+			float32(1),
+			[]metrics.Label{
+				telemetry.NewLabel(types.MetricsLabelModule, k.moduleName),
+				telemetry.NewLabel(types.MetricsLabelAddress, oracle.OracleAddress),
+			},
+		)
 	}
 
 	oracle.Online = false

--- a/x/crosschain/types/metrics.go
+++ b/x/crosschain/types/metrics.go
@@ -4,10 +4,12 @@ const (
 	MetricsKeyBridgeCallIn  = "bridge_call_in"
 	MetricsKeyBridgeCallOut = "bridge_call_out"
 	MetricsKeyOutgoingTx    = "outgoing_tx"
+	MetricsKeyOracleStatus  = "oracle_status"
 )
 
 const (
 	MetricsLabelModule   = "module"
 	MetricsLabelRefund   = "refund"
 	MetricsLabelTxOrigin = "tx_origin"
+	MetricsLabelAddress  = "address"
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced telemetry tracking for the oracle's online status during delegate addition and slashing.
	- Introduced new metrics keys and labels for improved observability related to oracle operations.

- **Bug Fixes**
	- Addressed potential oversight by ensuring telemetry metrics are set only when not in a check transaction context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->