### PR TITLE
feat(cmd): add a command to query pending execute claim

### DIFF
--- a/x/crosschain/client/cli/query.go
+++ b/x/crosschain/client/cli/query.go
@@ -91,6 +91,8 @@ func getQuerySubCmds(chainName string) []*cobra.Command {
 		// pending bridge call
 		CmdGetPendingBridgeCalls(chainName),
 		CmdGetPendingBridgeCall(chainName),
+
+		CmdGetPendingExecuteClaim(chainName),
 	}
 
 	for _, command := range cmds {
@@ -1049,5 +1051,33 @@ func CmdGetPendingBridgeCall(chainName string) *cobra.Command {
 			return clientCtx.PrintProto(res)
 		},
 	}
+	return cmd
+}
+
+func CmdGetPendingExecuteClaim(chainName string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pending-execute-claim",
+		Short: "Query pending execute claim",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+			queryClient := types.NewQueryClient(clientCtx)
+
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.PendingExecuteClaim(cmd.Context(), &types.QueryPendingExecuteClaimRequest{
+				ChainName:  chainName,
+				Pagination: pageReq,
+			})
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintProto(res)
+		},
+	}
+	flags.AddPaginationFlagsToCmd(cmd, "pending execute claim")
 	return cmd
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command in the CLI to query pending execute claims for a specified blockchain, enhancing user interaction with blockchain data.
	- Added pagination support for managing large sets of query results, improving user experience.

- **Bug Fixes**
	- Implemented error handling to ensure proper feedback for query execution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->