### PR TITLE
fix: update DelegateValidator address during ReDelegate

### DIFF
--- a/x/crosschain/keeper/msg_server.go
+++ b/x/crosschain/keeper/msg_server.go
@@ -220,6 +220,8 @@ func (s MsgServer) ReDelegate(c context.Context, msg *types.MsgReDelegate) (*typ
 	if _, err = s.stakingMsgServer.BeginRedelegate(c, msgBeginRedelegate); err != nil {
 		return nil, err
 	}
+	oracle.DelegateValidator = msg.ValidatorAddress
+	s.SetOracle(ctx, oracle)
 	return &types.MsgReDelegateResponse{}, err
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the redelegation functionality to ensure the oracle updates with the new validator address during redelegation processes. This improvement will allow for more accurate interactions with validator data.

- **Bug Fixes**
	- Addressed an issue with the `ReDelegate` function to ensure proper updating of the oracle's validator information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->