### PR TITLE
chore: replace v6.0 binary with v6.1

### DIFF
--- a/cosmovisor.Dockerfile
+++ b/cosmovisor.Dockerfile
@@ -10,6 +10,7 @@ COPY . .
 
 RUN make build
 
+FROM ghcr.io/functionx/fx-core:6.1.0 as fxv6
 FROM ghcr.io/functionx/fxcorevisor:7.4.0-rc6 as fxv7_4
 
 FROM alpine:3.18
@@ -30,6 +31,7 @@ ENV COSMOVISOR_COLOR_LOGS=true
 
 COPY --from=fxv7_4 /root/.fxcore/cosmovisor/genesis /root/.fxcore/cosmovisor/genesis
 COPY --from=fxv7_4 /root/.fxcore/cosmovisor/upgrades /root/.fxcore/cosmovisor/upgrades
+COPY --from=fxv6 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v6.0.x/bin/fxcored
 
 COPY --from=builder /go/bin/cosmovisor /usr/bin/cosmovisor
 COPY --from=builder /app/build/bin/fxcored /usr/bin/fxcored

--- a/cosmovisor_lite.Dockerfile
+++ b/cosmovisor_lite.Dockerfile
@@ -10,6 +10,7 @@ COPY . .
 
 RUN make build
 
+FROM ghcr.io/functionx/fx-core:6.1.0 as fxv6
 FROM ghcr.io/functionx/fxcorevisor-lite:7.4.0-rc6 as fxv7_4
 
 FROM alpine:3.18
@@ -30,6 +31,7 @@ ENV COSMOVISOR_COLOR_LOGS=true
 
 COPY --from=fxv7_4 /root/.fxcore/cosmovisor/genesis /root/.fxcore/cosmovisor/genesis
 COPY --from=fxv7_4 /root/.fxcore/cosmovisor/upgrades /root/.fxcore/cosmovisor/upgrades
+COPY --from=fxv6 /usr/bin/fxcored /root/.fxcore/cosmovisor/upgrades/v6.0.x/bin/fxcored
 
 COPY --from=builder /go/bin/cosmovisor /usr/bin/cosmovisor
 COPY --from=builder /app/build/bin/fxcored /usr/bin/fxcored


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated support for multiple versions of the `fxcored` binary in both `cosmovisor` and `cosmovisor_lite`.
	- Added a new base image to enhance functionality and compatibility with version 6.0.x of the `fxcored` binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->