### PR TITLE
chore: update test-nightly timeout to 20m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ test-count:
 	go test -mod=readonly -cpu 1 -count 1 -cover ./... | grep -v 'types\|cli\|no test files'
 
 test-nightly:
-	@TEST_INTEGRATION=true go test -mod=readonly -cpu 4 -v -run TestIntegrationTest ./tests
+	@TEST_INTEGRATION=true go test -mod=readonly -timeout 20m -cpu 4 -v -run TestIntegrationTest ./tests
 	@TEST_CROSSCHAIN=true go test -mod=readonly -cpu 4 -v -run TestCrosschainKeeperTestSuite ./x/crosschain/...
 
 mocks:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced integration testing by allowing tests to run for up to 20 minutes, preventing premature termination of longer tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->