### PR TITLE
chore: fix release note generation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ lint-install:
 lint: lint-install
 	echo "--> Running linter"
 	@golangci-lint run --build-tags=$(GO_BUILD) --out-format=tab
-	@if [ $$(find . -name '*.go' -type f | xargs grep 'nolint\|#nosec' | wc -l) -ne 43 ]; then \
+	@if [ $$(find . -name '*.go' -type f | xargs grep 'nolint\|#nosec' | wc -l) -ne 45 ]; then \
 		echo "\033[91m--> increase or decrease nolint, please recheck them\033[0m"; \
 		echo "\033[91m--> list nolint: \`find . -name '*.go' -type f | xargs grep 'nolint\|#nosec'\`\033[0m"; exit 1;\
 	fi

--- a/contrib/scripts/release-note.sh
+++ b/contrib/scripts/release-note.sh
@@ -5,19 +5,17 @@ set -o errexit -o nounset
 function find_change_log() {
   local file="$1"
   local version="$2"
-  local changelogs
-  changelogs="$(cat "$file")"
   local i
-  i="$(echo "$changelogs" | grep -n "\[$version" | cut -d: -f1)"
+  i="$(grep -n "\[$version\]" "$file" | cut -d: -f1 | head -n 1)"
   if [[ -z "$i" ]]; then
     echo "cannot find version $version" >&2 && return
   fi
   local j
-  j="$(echo "$changelogs" | tail -n +"$i" | grep -n "\-\-\-" | cut -d: -f1 | head -n 1)"
+  j="$(tail -n +"$i" "$file" | grep -n "\-\-\-" | cut -d: -f1 | head -n 1)"
   if [[ -z "$j" ]]; then
     echo "cannot find the end of $version's changelog" >&2 && exit 1
   fi
-  echo "$changelogs" | tail -n +"$i" | head -n "$j"
+  tail -n +"$i" "$file" | head -n "$j"
 }
 
 version=${1:-$VERSION}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the linting process to require 45 occurrences of 'nolint' or '#nosec' comments.
	- Optimized the changelog reading process in the release note script for better performance and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->