### PR TITLE
refactor: use sdk MsgTypeURL instead of string

### DIFF
--- a/x/gov/types/params.go
+++ b/x/gov/types/params.go
@@ -126,8 +126,7 @@ func EGFProposalParams(minDeposit []sdk.Coin, minInitialDeposit sdk.Coin, voting
 	maxDepositPeriod *time.Duration, threshold string, vetoThreshold, minInitialDepositRatio string, burnVoteQuorum, burnProposalDepositPrevote, burnVoteVeto bool,
 ) []*Params {
 	EGFMsgType := []string{
-		"/cosmos.distribution.v1beta1.CommunityPoolSpendProposal",
-		// TODO v1 MsgServer MsgCommunityPoolSpend pending
+		sdk.MsgTypeURL(&distributiontypes.MsgCommunityPoolSpend{}),
 	}
 	baseParams := make([]*Params, 0, len(EGFMsgType))
 	for _, msgType := range EGFMsgType {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced proposal parameters by transitioning to a dynamic message type for community pool spend proposals, improving maintainability and reducing potential errors. 

- **Bug Fixes**
	- Removed outdated comment regarding `MsgServer MsgCommunityPoolSpend`, reflecting updated implementation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->