### PR TITLE
test: refactor tests to use BaseSuite

### DIFF
--- a/testutil/helpers/helpers.go
+++ b/testutil/helpers/helpers.go
@@ -9,7 +9,6 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmed25519 "github.com/cometbft/cometbft/crypto/ed25519"
 	tmtypes "github.com/cometbft/cometbft/types"
-	tmtime "github.com/cometbft/cometbft/types/time"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -168,41 +167,4 @@ func AddTestAddr(myApp *app.App, ctx sdk.Context, addr sdk.AccAddress, coins sdk
 	if err != nil {
 		panic(err)
 	}
-}
-
-// Deprecated: please use BaseSuite.Commit
-func MintBlock(myApp *app.App, ctx sdk.Context, block ...int64) sdk.Context {
-	lastBlockHeight := ctx.BlockHeight()
-	nextHeight := lastBlockHeight + 1
-	if len(block) > 0 {
-		nextHeight = lastBlockHeight + block[0]
-	}
-	for i := lastBlockHeight; i < nextHeight; i++ {
-		// 1. try to finalize the block + commit finalizeBlockState
-		if _, err := myApp.FinalizeBlock(&abci.RequestFinalizeBlock{
-			Height:          i,
-			Time:            tmtime.Now(),
-			ProposerAddress: ctx.BlockHeader().ProposerAddress,
-		}); err != nil {
-			panic(err)
-		}
-
-		// 2. commit lastCommitInfo
-		if _, err := myApp.Commit(); err != nil {
-			panic(err)
-		}
-
-		// 3. prepare to process new blocks (myApp.GetContextForFinalizeBlock(nil))
-		if _, err := myApp.ProcessProposal(&abci.RequestProcessProposal{
-			Height:          i + 1,
-			Time:            tmtime.Now(),
-			ProposerAddress: ctx.BlockHeader().ProposerAddress,
-		}); err != nil {
-			panic(err)
-		}
-
-		// 4. get new ctx for finalizeBlockState
-		ctx = myApp.GetContextForFinalizeBlock(nil)
-	}
-	return ctx
 }

--- a/testutil/helpers/suite.go
+++ b/testutil/helpers/suite.go
@@ -33,9 +33,11 @@ func (s *BaseSuite) SetupTest() {
 	}
 	valSet, valAccounts, valBalances := GenerateGenesisValidator(valNumber, sdk.Coins{})
 	s.ValSet = valSet
-	for _, account := range valAccounts {
-		s.ValAddr = append(s.ValAddr, account.GetAddress().Bytes())
+	s.ValAddr = make([]sdk.ValAddress, valNumber)
+	for i := 0; i < valNumber; i++ {
+		s.ValAddr[i] = valAccounts[i].GetAddress().Bytes()
 	}
+
 	s.App = SetupWithGenesisValSet(s.T(), valSet, valAccounts, valBalances...)
 	s.Ctx = s.App.GetContextForFinalizeBlock(nil)
 	s.Ctx = s.Ctx.WithProposer(s.ValSet.Proposer.Address.Bytes())

--- a/x/crosschain/keeper/abci_test.go
+++ b/x/crosschain/keeper/abci_test.go
@@ -19,14 +19,14 @@ func (suite *KeeperTestSuite) TestABCIEndBlockDepositClaim() {
 		OracleAddress:    suite.oracleAddrs[0].String(),
 		BridgerAddress:   suite.bridgerAddrs[0].String(),
 		ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[0].PublicKey),
-		ValidatorAddress: suite.valAddrs[0].String(),
+		ValidatorAddress: suite.ValAddr[0].String(),
 		DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(10 * 1e3).MulRaw(1e18)),
 		ChainName:        suite.chainName,
 	}
-	_, err := suite.MsgServer().BondedOracle(suite.ctx, normalMsg)
+	_, err := suite.MsgServer().BondedOracle(suite.Ctx, normalMsg)
 	suite.Require().NoError(err)
 
-	suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
+	suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
 
 	suite.EndBlocker()
 
@@ -47,7 +47,7 @@ func (suite *KeeperTestSuite) TestABCIEndBlockDepositClaim() {
 	err = suite.SendClaimReturnErr(addBridgeTokenClaim)
 	suite.Require().NoError(err)
 
-	suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
+	suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
 	suite.EndBlocker()
 
 	sendToFxClaim := &types.MsgSendToFxClaim{
@@ -63,10 +63,10 @@ func (suite *KeeperTestSuite) TestABCIEndBlockDepositClaim() {
 	}
 	suite.SendClaim(sendToFxClaim)
 
-	suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
+	suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
 	suite.EndBlocker()
 
-	allBalances := suite.app.BankKeeper.GetAllBalances(suite.ctx, sdk.MustAccAddressFromBech32(sendToFxClaim.Receiver))
+	allBalances := suite.App.BankKeeper.GetAllBalances(suite.Ctx, sdk.MustAccAddressFromBech32(sendToFxClaim.Receiver))
 	denom := types.NewBridgeDenom(suite.chainName, bridgeToken)
 	trace, err := fxtypes.GetIbcDenomTrace(denom, addBridgeTokenClaim.ChannelIbc)
 	suite.NoError(err)
@@ -83,21 +83,21 @@ func (suite *KeeperTestSuite) TestOracleUpdate() {
 			OracleAddress:    suite.oracleAddrs[i].String(),
 			BridgerAddress:   suite.bridgerAddrs[i].String(),
 			ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[i].PublicKey),
-			ValidatorAddress: suite.valAddrs[i].String(),
+			ValidatorAddress: suite.ValAddr[i].String(),
 			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(10 * 1e3).MulRaw(1e18)),
 			ChainName:        suite.chainName,
 		}
 		suite.Require().NoError(msgBondedOracle.ValidateBasic())
-		_, err := suite.MsgServer().BondedOracle(suite.ctx, msgBondedOracle)
+		_, err := suite.MsgServer().BondedOracle(suite.Ctx, msgBondedOracle)
 
 		suite.Require().NoError(err)
 		suite.EndBlocker()
-		suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
-		oracleSets := suite.Keeper().GetOracleSets(suite.ctx)
+		suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
+		oracleSets := suite.Keeper().GetOracleSets(suite.Ctx)
 		suite.Require().NotNil(oracleSets)
 		suite.Require().EqualValues(i+1, len(oracleSets))
 
-		power := suite.Keeper().GetLastTotalPower(suite.ctx)
+		power := suite.Keeper().GetLastTotalPower(suite.Ctx)
 		expectPower := sdkmath.NewInt(10 * 1e3).MulRaw(1e18).Mul(sdkmath.NewInt(int64(i + 1))).Quo(sdk.DefaultPowerReduction)
 		suite.Require().True(expectPower.Equal(power))
 	}
@@ -118,15 +118,15 @@ func (suite *KeeperTestSuite) TestOracleUpdate() {
 		}
 		err := suite.SendClaimReturnErr(addBridgeTokenClaim)
 		suite.Require().NoError(err)
-		endBlockBeforeAttestation := suite.Keeper().GetAttestation(suite.ctx, addBridgeTokenClaim.EventNonce, addBridgeTokenClaim.ClaimHash())
+		endBlockBeforeAttestation := suite.Keeper().GetAttestation(suite.Ctx, addBridgeTokenClaim.EventNonce, addBridgeTokenClaim.ClaimHash())
 		suite.Require().NotNil(endBlockBeforeAttestation)
 		suite.Require().False(endBlockBeforeAttestation.Observed)
 		suite.Require().NotNil(endBlockBeforeAttestation.Votes)
 		suite.Require().EqualValues(i+1, len(endBlockBeforeAttestation.Votes))
 
 		suite.EndBlocker()
-		suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
-		endBlockAfterAttestation := suite.Keeper().GetAttestation(suite.ctx, addBridgeTokenClaim.EventNonce, addBridgeTokenClaim.ClaimHash())
+		suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
+		endBlockAfterAttestation := suite.Keeper().GetAttestation(suite.Ctx, addBridgeTokenClaim.EventNonce, addBridgeTokenClaim.ClaimHash())
 		suite.Require().NotNil(endBlockAfterAttestation)
 		suite.Require().False(endBlockAfterAttestation.Observed)
 	}
@@ -145,8 +145,8 @@ func (suite *KeeperTestSuite) TestOracleUpdate() {
 	err := suite.SendClaimReturnErr(addBridgeTokenClaim)
 	suite.Require().NoError(err)
 	suite.EndBlocker()
-	suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
-	attestation := suite.Keeper().GetAttestation(suite.ctx, addBridgeTokenClaim.EventNonce, addBridgeTokenClaim.ClaimHash())
+	suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
+	attestation := suite.Keeper().GetAttestation(suite.Ctx, addBridgeTokenClaim.EventNonce, addBridgeTokenClaim.ClaimHash())
 
 	suite.Require().NotNil(attestation)
 	suite.Require().True(attestation.Observed)
@@ -155,7 +155,7 @@ func (suite *KeeperTestSuite) TestOracleUpdate() {
 	for i := 0; i < 7; i++ {
 		newOracleList = append(newOracleList, suite.oracleAddrs[i].String())
 	}
-	_, err = suite.MsgServer().UpdateChainOracles(suite.ctx, &types.MsgUpdateChainOracles{
+	_, err = suite.MsgServer().UpdateChainOracles(suite.Ctx, &types.MsgUpdateChainOracles{
 		ChainName: suite.chainName,
 		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		Oracles:   newOracleList,
@@ -164,7 +164,7 @@ func (suite *KeeperTestSuite) TestOracleUpdate() {
 	suite.Require().ErrorIs(types.ErrInvalid, err)
 
 	expectTotalPower := sdkmath.NewInt(10 * 1e3).MulRaw(1e18).Mul(sdkmath.NewInt(10)).Quo(sdk.DefaultPowerReduction)
-	actualTotalPower := suite.Keeper().GetLastTotalPower(suite.ctx)
+	actualTotalPower := suite.Keeper().GetLastTotalPower(suite.Ctx)
 	suite.Require().True(expectTotalPower.Equal(actualTotalPower))
 
 	expectMaxChangePower := types.AttestationProposalOracleChangePowerThreshold.Mul(expectTotalPower).Quo(sdkmath.NewInt(100))
@@ -176,7 +176,7 @@ func (suite *KeeperTestSuite) TestOracleUpdate() {
 	for i := 0; i < 8; i++ {
 		newOracleList2 = append(newOracleList2, suite.oracleAddrs[i].String())
 	}
-	_, err = suite.MsgServer().UpdateChainOracles(suite.ctx, &types.MsgUpdateChainOracles{
+	_, err = suite.MsgServer().UpdateChainOracles(suite.Ctx, &types.MsgUpdateChainOracles{
 		ChainName: suite.chainName,
 		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		Oracles:   newOracleList2,
@@ -193,19 +193,19 @@ func (suite *KeeperTestSuite) TestAttestationAfterOracleUpdate() {
 			OracleAddress:    suite.oracleAddrs[i].String(),
 			BridgerAddress:   suite.bridgerAddrs[i].String(),
 			ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[i].PublicKey),
-			ValidatorAddress: suite.valAddrs[i].String(),
+			ValidatorAddress: suite.ValAddr[i].String(),
 			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(10 * 1e3).MulRaw(1e18)),
 			ChainName:        suite.chainName,
 		}
-		_, err := suite.MsgServer().BondedOracle(suite.ctx, msgBondedOracle)
+		_, err := suite.MsgServer().BondedOracle(suite.Ctx, msgBondedOracle)
 		suite.Require().NoError(err)
 		suite.EndBlocker()
-		suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
-		oracleSets := suite.Keeper().GetOracleSets(suite.ctx)
+		suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
+		oracleSets := suite.Keeper().GetOracleSets(suite.Ctx)
 		suite.Require().NotNil(oracleSets)
 		suite.Require().EqualValues(i+1, len(oracleSets))
 
-		power := suite.Keeper().GetLastTotalPower(suite.ctx)
+		power := suite.Keeper().GetLastTotalPower(suite.Ctx)
 		expectPower := sdkmath.NewInt(10 * 1e3).MulRaw(1e18).Mul(sdkmath.NewInt(int64(i + 1))).Quo(sdk.DefaultPowerReduction)
 		suite.Require().True(expectPower.Equal(power))
 	}
@@ -227,13 +227,13 @@ func (suite *KeeperTestSuite) TestAttestationAfterOracleUpdate() {
 			firstBridgeTokenClaim.BridgerAddress = suite.bridgerAddrs[i].String()
 			err := suite.SendClaimReturnErr(firstBridgeTokenClaim)
 			suite.Require().NoError(err)
-			endBlockBeforeAttestation := suite.Keeper().GetAttestation(suite.ctx, firstBridgeTokenClaim.EventNonce, firstBridgeTokenClaim.ClaimHash())
+			endBlockBeforeAttestation := suite.Keeper().GetAttestation(suite.Ctx, firstBridgeTokenClaim.EventNonce, firstBridgeTokenClaim.ClaimHash())
 			suite.Require().NotNil(endBlockBeforeAttestation)
 			suite.Require().False(endBlockBeforeAttestation.Observed)
 			suite.Require().NotNil(endBlockBeforeAttestation.Votes)
 			suite.Require().EqualValues(i+1, len(endBlockBeforeAttestation.Votes))
 
-			endBlockAfterAttestation := suite.Keeper().GetAttestation(suite.ctx, firstBridgeTokenClaim.EventNonce, firstBridgeTokenClaim.ClaimHash())
+			endBlockAfterAttestation := suite.Keeper().GetAttestation(suite.Ctx, firstBridgeTokenClaim.EventNonce, firstBridgeTokenClaim.ClaimHash())
 			suite.Require().NotNil(endBlockAfterAttestation)
 			suite.Require().False(endBlockAfterAttestation.Observed)
 		}
@@ -242,8 +242,8 @@ func (suite *KeeperTestSuite) TestAttestationAfterOracleUpdate() {
 		err := suite.SendClaimReturnErr(firstBridgeTokenClaim)
 		suite.Require().NoError(err)
 		suite.EndBlocker()
-		suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
-		attestation := suite.Keeper().GetAttestation(suite.ctx, firstBridgeTokenClaim.EventNonce, firstBridgeTokenClaim.ClaimHash())
+		suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
+		attestation := suite.Keeper().GetAttestation(suite.Ctx, firstBridgeTokenClaim.EventNonce, firstBridgeTokenClaim.ClaimHash())
 
 		suite.Require().NotNil(attestation)
 		suite.Require().True(attestation.Observed)
@@ -266,20 +266,20 @@ func (suite *KeeperTestSuite) TestAttestationAfterOracleUpdate() {
 			secondBridgeTokenClaim.BridgerAddress = suite.bridgerAddrs[i].String()
 			err := suite.SendClaimReturnErr(secondBridgeTokenClaim)
 			suite.Require().NoError(err)
-			endBlockBeforeAttestation := suite.Keeper().GetAttestation(suite.ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
+			endBlockBeforeAttestation := suite.Keeper().GetAttestation(suite.Ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
 			suite.Require().NotNil(endBlockBeforeAttestation)
 			suite.Require().False(endBlockBeforeAttestation.Observed)
 			suite.Require().NotNil(endBlockBeforeAttestation.Votes)
 			suite.Require().EqualValues(i+1, len(endBlockBeforeAttestation.Votes))
 
 			suite.EndBlocker()
-			suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
-			endBlockAfterAttestation := suite.Keeper().GetAttestation(suite.ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
+			suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
+			endBlockAfterAttestation := suite.Keeper().GetAttestation(suite.Ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
 			suite.Require().NotNil(endBlockAfterAttestation)
 			suite.Require().False(endBlockAfterAttestation.Observed)
 		}
 
-		secondClaimAttestation := suite.Keeper().GetAttestation(suite.ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
+		secondClaimAttestation := suite.Keeper().GetAttestation(suite.Ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
 		suite.Require().NotNil(secondClaimAttestation)
 		suite.Require().False(secondClaimAttestation.Observed)
 		suite.Require().NotNil(secondClaimAttestation.Votes)
@@ -289,22 +289,22 @@ func (suite *KeeperTestSuite) TestAttestationAfterOracleUpdate() {
 		for i := 0; i < 15; i++ {
 			newOracleList = append(newOracleList, suite.oracleAddrs[i].String())
 		}
-		_, err := suite.MsgServer().UpdateChainOracles(suite.ctx, &types.MsgUpdateChainOracles{
+		_, err := suite.MsgServer().UpdateChainOracles(suite.Ctx, &types.MsgUpdateChainOracles{
 			Oracles:   newOracleList,
 			Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 			ChainName: suite.chainName,
 		})
 		suite.Require().NoError(err)
-		suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
+		suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
 		suite.EndBlocker()
 
-		secondClaimAttestation = suite.Keeper().GetAttestation(suite.ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
+		secondClaimAttestation = suite.Keeper().GetAttestation(suite.Ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
 		suite.Require().NotNil(secondClaimAttestation)
 		suite.Require().False(secondClaimAttestation.Observed)
 		suite.Require().NotNil(secondClaimAttestation.Votes)
 		suite.Require().EqualValues(6, len(secondClaimAttestation.Votes))
 
-		activeOracles := suite.Keeper().GetAllOracles(suite.ctx, true)
+		activeOracles := suite.Keeper().GetAllOracles(suite.Ctx, true)
 		suite.Require().NotNil(activeOracles)
 		suite.Require().EqualValues(15, len(activeOracles))
 		for i := 0; i < 15; i++ {
@@ -315,22 +315,22 @@ func (suite *KeeperTestSuite) TestAttestationAfterOracleUpdate() {
 		for i := 0; i < 11; i++ {
 			newOracleList2 = append(newOracleList2, suite.oracleAddrs[i].String())
 		}
-		_, err = suite.MsgServer().UpdateChainOracles(suite.ctx, &types.MsgUpdateChainOracles{
+		_, err = suite.MsgServer().UpdateChainOracles(suite.Ctx, &types.MsgUpdateChainOracles{
 			Oracles:   newOracleList2,
 			Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 			ChainName: suite.chainName,
 		})
 		suite.Require().NoError(err)
-		suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
+		suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
 		suite.EndBlocker()
 
-		secondClaimAttestation = suite.Keeper().GetAttestation(suite.ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
+		secondClaimAttestation = suite.Keeper().GetAttestation(suite.Ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
 		suite.Require().NotNil(secondClaimAttestation)
 		suite.Require().False(secondClaimAttestation.Observed)
 		suite.Require().NotNil(secondClaimAttestation.Votes)
 		suite.Require().EqualValues(6, len(secondClaimAttestation.Votes))
 
-		activeOracles = suite.Keeper().GetAllOracles(suite.ctx, true)
+		activeOracles = suite.Keeper().GetAllOracles(suite.Ctx, true)
 		suite.Require().NotNil(activeOracles)
 		suite.Require().EqualValues(11, len(activeOracles))
 		for i := 0; i < 11; i++ {
@@ -341,22 +341,22 @@ func (suite *KeeperTestSuite) TestAttestationAfterOracleUpdate() {
 		for i := 0; i < 10; i++ {
 			newOracleList3 = append(newOracleList3, suite.oracleAddrs[i].String())
 		}
-		_, err = suite.MsgServer().UpdateChainOracles(suite.ctx, &types.MsgUpdateChainOracles{
+		_, err = suite.MsgServer().UpdateChainOracles(suite.Ctx, &types.MsgUpdateChainOracles{
 			Oracles:   newOracleList3,
 			Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 			ChainName: suite.chainName,
 		})
 		suite.Require().NoError(err)
-		suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
+		suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
 		suite.EndBlocker()
 
-		secondClaimAttestation = suite.Keeper().GetAttestation(suite.ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
+		secondClaimAttestation = suite.Keeper().GetAttestation(suite.Ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
 		suite.Require().NotNil(secondClaimAttestation)
 		suite.Require().False(secondClaimAttestation.Observed)
 		suite.Require().NotNil(secondClaimAttestation.Votes)
 		suite.Require().EqualValues(6, len(secondClaimAttestation.Votes))
 
-		activeOracles = suite.Keeper().GetAllOracles(suite.ctx, true)
+		activeOracles = suite.Keeper().GetAllOracles(suite.Ctx, true)
 		suite.Require().NotNil(activeOracles)
 		suite.Require().EqualValues(10, len(activeOracles))
 		for i := 0; i < 10; i++ {
@@ -367,10 +367,10 @@ func (suite *KeeperTestSuite) TestAttestationAfterOracleUpdate() {
 		err = suite.SendClaimReturnErr(secondBridgeTokenClaim)
 		suite.Require().NoError(err)
 
-		suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
+		suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
 		suite.EndBlocker()
 
-		secondClaimAttestation = suite.Keeper().GetAttestation(suite.ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
+		secondClaimAttestation = suite.Keeper().GetAttestation(suite.Ctx, secondBridgeTokenClaim.EventNonce, secondBridgeTokenClaim.ClaimHash())
 		suite.Require().NotNil(secondClaimAttestation)
 		suite.Require().True(secondClaimAttestation.Observed)
 		suite.Require().NotNil(secondClaimAttestation.Votes)
@@ -384,17 +384,17 @@ func (suite *KeeperTestSuite) TestOracleDelete() {
 			OracleAddress:    suite.oracleAddrs[i].String(),
 			BridgerAddress:   suite.bridgerAddrs[i].String(),
 			ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[i].PublicKey),
-			ValidatorAddress: suite.valAddrs[i].String(),
+			ValidatorAddress: suite.ValAddr[i].String(),
 			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(10 * 1e3).MulRaw(1e18)),
 			ChainName:        suite.chainName,
 		}
 		suite.Require().NoError(msgBondedOracle.ValidateBasic())
-		_, err := suite.MsgServer().BondedOracle(suite.ctx, msgBondedOracle)
+		_, err := suite.MsgServer().BondedOracle(suite.Ctx, msgBondedOracle)
 		suite.Require().NoError(err)
 	}
 	suite.EndBlocker()
-	suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
-	allOracles := suite.Keeper().GetAllOracles(suite.ctx, false)
+	suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
+	allOracles := suite.Keeper().GetAllOracles(suite.Ctx, false)
 	suite.Require().NotNil(allOracles)
 	suite.Require().EqualValues(len(suite.oracleAddrs), len(allOracles))
 
@@ -402,15 +402,15 @@ func (suite *KeeperTestSuite) TestOracleDelete() {
 	bridger := suite.bridgerAddrs[0]
 	externalAddress := suite.PubKeyToExternalAddr(suite.externalPris[0].PublicKey)
 
-	oracleAddr, found := suite.Keeper().GetOracleAddrByBridgerAddr(suite.ctx, bridger)
+	oracleAddr, found := suite.Keeper().GetOracleAddrByBridgerAddr(suite.Ctx, bridger)
 	suite.Require().True(found)
 	suite.Require().EqualValues(oracle.String(), oracleAddr.String())
 
-	oracleAddr, found = suite.Keeper().GetOracleAddrByExternalAddr(suite.ctx, externalAddress)
+	oracleAddr, found = suite.Keeper().GetOracleAddrByExternalAddr(suite.Ctx, externalAddress)
 	suite.Require().True(found)
 	suite.Require().EqualValues(oracle.String(), oracleAddr.String())
 
-	oracleData, found := suite.Keeper().GetOracle(suite.ctx, oracle)
+	oracleData, found := suite.Keeper().GetOracle(suite.Ctx, oracle)
 	suite.Require().True(found)
 	suite.Require().NotNil(oracleData)
 	suite.Require().EqualValues(oracle.String(), oracleData.OracleAddress)
@@ -424,24 +424,24 @@ func (suite *KeeperTestSuite) TestOracleDelete() {
 		newOracleAddressList = append(newOracleAddressList, address.String())
 	}
 
-	_, err := suite.MsgServer().UpdateChainOracles(suite.ctx, &types.MsgUpdateChainOracles{
+	_, err := suite.MsgServer().UpdateChainOracles(suite.Ctx, &types.MsgUpdateChainOracles{
 		Oracles:   newOracleAddressList,
 		Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		ChainName: suite.chainName,
 	})
 	suite.Require().NoError(err)
-	suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
+	suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
 	suite.EndBlocker()
 
-	oracleAddr, found = suite.Keeper().GetOracleAddrByBridgerAddr(suite.ctx, bridger)
+	oracleAddr, found = suite.Keeper().GetOracleAddrByBridgerAddr(suite.Ctx, bridger)
 	suite.Require().True(found)
 	suite.Require().Equal(oracleAddr, oracle)
 
-	oracleAddr, found = suite.Keeper().GetOracleAddrByExternalAddr(suite.ctx, externalAddress)
+	oracleAddr, found = suite.Keeper().GetOracleAddrByExternalAddr(suite.Ctx, externalAddress)
 	suite.Require().True(found)
 	suite.Require().Equal(oracleAddr, oracle)
 
-	oracleData, found = suite.Keeper().GetOracle(suite.ctx, oracle)
+	oracleData, found = suite.Keeper().GetOracle(suite.Ctx, oracle)
 	suite.Require().True(found)
 }
 
@@ -451,22 +451,22 @@ func (suite *KeeperTestSuite) TestOracleSetSlash() {
 			OracleAddress:    suite.oracleAddrs[i].String(),
 			BridgerAddress:   suite.bridgerAddrs[i].String(),
 			ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[i].PublicKey),
-			ValidatorAddress: suite.valAddrs[i].String(),
+			ValidatorAddress: suite.ValAddr[i].String(),
 			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(10 * 1e3).MulRaw(1e18)),
 			ChainName:        suite.chainName,
 		}
 		suite.Require().NoError(msgBondedOracle.ValidateBasic())
-		_, err := suite.MsgServer().BondedOracle(suite.ctx, msgBondedOracle)
+		_, err := suite.MsgServer().BondedOracle(suite.Ctx, msgBondedOracle)
 		suite.Require().NoError(err)
 	}
-	suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
-	suite.Keeper().EndBlocker(suite.ctx)
+	suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
+	suite.Keeper().EndBlocker(suite.Ctx)
 
-	allOracles := suite.Keeper().GetAllOracles(suite.ctx, false)
+	allOracles := suite.Keeper().GetAllOracles(suite.Ctx, false)
 	suite.Require().NotNil(allOracles)
 	suite.Require().Equal(len(suite.oracleAddrs), len(allOracles))
 
-	oracleSets := suite.Keeper().GetOracleSets(suite.ctx)
+	oracleSets := suite.Keeper().GetOracleSets(suite.Ctx)
 	suite.Require().NotNil(oracleSets)
 	suite.Require().EqualValues(1, len(oracleSets))
 
@@ -480,24 +480,24 @@ func (suite *KeeperTestSuite) TestOracleSetSlash() {
 			ChainName:       suite.chainName,
 		}
 		suite.Require().NoError(oracleSetConfirm.ValidateBasic())
-		_, err := suite.MsgServer().OracleSetConfirm(suite.ctx, oracleSetConfirm)
+		_, err := suite.MsgServer().OracleSetConfirm(suite.Ctx, oracleSetConfirm)
 		suite.Require().NoError(err)
 	}
 
-	suite.Keeper().EndBlocker(suite.ctx)
+	suite.Keeper().EndBlocker(suite.Ctx)
 	oracleSetHeight := int64(oracleSets[0].Height)
-	suite.ctx = suite.ctx.WithBlockHeight(suite.ctx.BlockHeight() + 1)
+	suite.Ctx = suite.Ctx.WithBlockHeight(suite.Ctx.BlockHeight() + 1)
 	suite.EndBlocker()
 
-	oracle, found := suite.Keeper().GetOracle(suite.ctx, suite.oracleAddrs[len(suite.oracleAddrs)-1])
+	oracle, found := suite.Keeper().GetOracle(suite.Ctx, suite.oracleAddrs[len(suite.oracleAddrs)-1])
 	suite.Require().True(found)
 	suite.Require().True(oracle.Online)
 	suite.Require().Equal(int64(0), oracle.SlashTimes)
 
-	suite.ctx = suite.ctx.WithBlockHeight(oracleSetHeight + int64(suite.Keeper().GetParams(suite.ctx).SignedWindow) + 1)
-	suite.Keeper().EndBlocker(suite.ctx)
+	suite.Ctx = suite.Ctx.WithBlockHeight(oracleSetHeight + int64(suite.Keeper().GetParams(suite.Ctx).SignedWindow) + 1)
+	suite.Keeper().EndBlocker(suite.Ctx)
 
-	oracle, found = suite.Keeper().GetOracle(suite.ctx, suite.oracleAddrs[len(suite.oracleAddrs)-1])
+	oracle, found = suite.Keeper().GetOracle(suite.Ctx, suite.oracleAddrs[len(suite.oracleAddrs)-1])
 	suite.Require().True(found)
 	suite.Require().False(oracle.Online)
 	suite.Require().Equal(int64(1), oracle.SlashTimes)
@@ -509,27 +509,27 @@ func (suite *KeeperTestSuite) TestSlashOracle() {
 			OracleAddress:    suite.oracleAddrs[i].String(),
 			BridgerAddress:   suite.bridgerAddrs[i].String(),
 			ExternalAddress:  suite.PubKeyToExternalAddr(suite.externalPris[i].PublicKey),
-			ValidatorAddress: suite.valAddrs[i].String(),
+			ValidatorAddress: suite.ValAddr[i].String(),
 			DelegateAmount:   types.NewDelegateAmount(sdkmath.NewInt(10 * 1e3).MulRaw(1e18)),
 			ChainName:        suite.chainName,
 		}
 		suite.Require().NoError(msgBondedOracle.ValidateBasic())
-		_, err := suite.MsgServer().BondedOracle(suite.ctx, msgBondedOracle)
+		_, err := suite.MsgServer().BondedOracle(suite.Ctx, msgBondedOracle)
 		suite.Require().NoError(err)
 	}
 
-	params := suite.Keeper().GetParams(suite.ctx)
-	err := suite.Keeper().SetParams(suite.ctx, &params)
+	params := suite.Keeper().GetParams(suite.Ctx)
+	err := suite.Keeper().SetParams(suite.Ctx, &params)
 	suite.Require().NoError(err)
 	for i := 0; i < len(suite.oracleAddrs); i++ {
-		oracle, found := suite.Keeper().GetOracle(suite.ctx, suite.oracleAddrs[i])
+		oracle, found := suite.Keeper().GetOracle(suite.Ctx, suite.oracleAddrs[i])
 		suite.Require().True(found)
 		suite.Require().True(oracle.Online)
 		suite.Require().Equal(int64(0), oracle.SlashTimes)
 
-		suite.Keeper().SlashOracle(suite.ctx, oracle.OracleAddress)
+		suite.Keeper().SlashOracle(suite.Ctx, oracle.OracleAddress)
 
-		oracle, found = suite.Keeper().GetOracle(suite.ctx, suite.oracleAddrs[i])
+		oracle, found = suite.Keeper().GetOracle(suite.Ctx, suite.oracleAddrs[i])
 		suite.Require().True(found)
 		suite.Require().False(oracle.Online)
 		suite.Require().Equal(int64(1), oracle.SlashTimes)
@@ -537,14 +537,14 @@ func (suite *KeeperTestSuite) TestSlashOracle() {
 
 	// repeat slash test.
 	for i := 0; i < len(suite.oracleAddrs); i++ {
-		oracle, found := suite.Keeper().GetOracle(suite.ctx, suite.oracleAddrs[i])
+		oracle, found := suite.Keeper().GetOracle(suite.Ctx, suite.oracleAddrs[i])
 		suite.Require().True(found)
 		suite.Require().False(oracle.Online)
 		suite.Require().Equal(int64(1), oracle.SlashTimes)
 
-		suite.Keeper().SlashOracle(suite.ctx, oracle.OracleAddress)
+		suite.Keeper().SlashOracle(suite.Ctx, oracle.OracleAddress)
 
-		oracle, found = suite.Keeper().GetOracle(suite.ctx, suite.oracleAddrs[i])
+		oracle, found = suite.Keeper().GetOracle(suite.Ctx, suite.oracleAddrs[i])
 		suite.Require().True(found)
 		suite.Require().False(oracle.Online)
 		suite.Require().Equal(int64(1), oracle.SlashTimes)

--- a/x/crosschain/keeper/batch_test.go
+++ b/x/crosschain/keeper/batch_test.go
@@ -41,8 +41,8 @@ func (suite *KeeperTestSuite) TestLastPendingBatchRequestByAddr() {
 		},
 	}
 	for i := uint64(1); i <= 3; i++ {
-		suite.ctx = suite.ctx.WithBlockHeight(int64(i))
-		err := suite.Keeper().StoreBatch(suite.ctx, &types.OutgoingTxBatch{
+		suite.Ctx = suite.Ctx.WithBlockHeight(int64(i))
+		err := suite.Keeper().StoreBatch(suite.Ctx, &types.OutgoingTxBatch{
 			Block:      i,
 			BatchNonce: i,
 			Transactions: types.OutgoingTransferTxs{{
@@ -54,7 +54,7 @@ func (suite *KeeperTestSuite) TestLastPendingBatchRequestByAddr() {
 		suite.Require().NoError(err)
 	}
 
-	wrapSDKContext := suite.ctx
+	wrapSDKContext := suite.Ctx
 	for _, testCase := range testCases {
 		oracle := types.Oracle{
 			OracleAddress:  testCase.OracleAddress.String(),
@@ -62,8 +62,8 @@ func (suite *KeeperTestSuite) TestLastPendingBatchRequestByAddr() {
 			StartHeight:    testCase.StartHeight,
 		}
 		// save oracle
-		suite.Keeper().SetOracle(suite.ctx, oracle)
-		suite.Keeper().SetOracleAddrByBridgerAddr(suite.ctx, testCase.BridgerAddress, oracle.GetOracle())
+		suite.Keeper().SetOracle(suite.Ctx, oracle)
+		suite.Keeper().SetOracleAddrByBridgerAddr(suite.Ctx, testCase.BridgerAddress, oracle.GetOracle())
 
 		response, err := suite.QueryClient().LastPendingBatchRequestByAddr(wrapSDKContext,
 			&types.QueryLastPendingBatchRequestByAddrRequest{
@@ -100,10 +100,10 @@ func (suite *KeeperTestSuite) TestKeeper_DeleteBatchConfig() {
 		Block:         100,
 		FeeReceive:    helpers.GenHexAddress().Hex(),
 	}
-	suite.NoError(suite.Keeper().StoreBatch(suite.ctx, batch))
+	suite.NoError(suite.Keeper().StoreBatch(suite.Ctx, batch))
 
-	suite.Equal(uint64(0), suite.Keeper().GetLastSlashedBatchBlock(suite.ctx))
-	batches := suite.Keeper().GetUnSlashedBatches(suite.ctx, batch.Block+1)
+	suite.Equal(uint64(0), suite.Keeper().GetLastSlashedBatchBlock(suite.Ctx))
+	batches := suite.Keeper().GetUnSlashedBatches(suite.Ctx, batch.Block+1)
 	suite.Equal(1, len(batches))
 
 	msgConfirmBatch := &types.MsgConfirmBatch{
@@ -114,14 +114,14 @@ func (suite *KeeperTestSuite) TestKeeper_DeleteBatchConfig() {
 	for i, oracle := range suite.oracleAddrs {
 		msgConfirmBatch.BridgerAddress = suite.bridgerAddrs[i].String()
 		msgConfirmBatch.ExternalAddress = crypto.PubkeyToAddress(suite.externalPris[i].PublicKey).String()
-		suite.Keeper().SetBatchConfirm(suite.ctx, oracle, msgConfirmBatch)
+		suite.Keeper().SetBatchConfirm(suite.Ctx, oracle, msgConfirmBatch)
 	}
-	suite.Keeper().OutgoingTxBatchExecuted(suite.ctx, batch.TokenContract, batch.BatchNonce)
+	suite.Keeper().OutgoingTxBatchExecuted(suite.Ctx, batch.TokenContract, batch.BatchNonce)
 
 	for _, oracle := range suite.oracleAddrs {
-		suite.Nil(suite.Keeper().GetBatchConfirm(suite.ctx, batch.TokenContract, batch.BatchNonce, oracle))
+		suite.Nil(suite.Keeper().GetBatchConfirm(suite.Ctx, batch.TokenContract, batch.BatchNonce, oracle))
 	}
-	suite.Nil(suite.Keeper().GetOutgoingTxBatch(suite.ctx, batch.TokenContract, batch.BatchNonce))
+	suite.Nil(suite.Keeper().GetOutgoingTxBatch(suite.Ctx, batch.TokenContract, batch.BatchNonce))
 }
 
 func (suite *KeeperTestSuite) TestKeeper_IterateBatchBySlashedBatchBlock() {
@@ -150,10 +150,10 @@ func (suite *KeeperTestSuite) TestKeeper_IterateBatchBySlashedBatchBlock() {
 			Block:         uint64(100 + i),
 			FeeReceive:    helpers.GenHexAddress().Hex(),
 		}
-		suite.NoError(suite.Keeper().StoreBatch(suite.ctx, batch))
+		suite.NoError(suite.Keeper().StoreBatch(suite.Ctx, batch))
 	}
 	var batchs []*types.OutgoingTxBatch
-	suite.Keeper().IterateBatchByBlockHeight(suite.ctx, 100+1, uint64(100+index+1),
+	suite.Keeper().IterateBatchByBlockHeight(suite.Ctx, 100+1, uint64(100+index+1),
 		func(batch *types.OutgoingTxBatch) bool {
 			batchs = append(batchs, batch)
 			return false

--- a/x/crosschain/keeper/bridge_token_test.go
+++ b/x/crosschain/keeper/bridge_token_test.go
@@ -7,18 +7,18 @@ import (
 
 func (suite *KeeperTestSuite) TestKeeper_BridgeToken() {
 	tokenContract := helpers.GenHexAddress().Hex()
-	denom, err := suite.Keeper().SetIbcDenomTrace(suite.ctx, tokenContract, "")
+	denom, err := suite.Keeper().SetIbcDenomTrace(suite.Ctx, tokenContract, "")
 	suite.NoError(err)
 	suite.Equal(types.NewBridgeDenom(suite.chainName, tokenContract), denom)
 
-	suite.Keeper().AddBridgeToken(suite.ctx, tokenContract, denom)
+	suite.Keeper().AddBridgeToken(suite.Ctx, tokenContract, denom)
 
 	bridgeToken := &types.BridgeToken{Token: tokenContract, Denom: denom}
-	suite.EqualValues(bridgeToken, suite.Keeper().GetBridgeTokenDenom(suite.ctx, tokenContract))
+	suite.EqualValues(bridgeToken, suite.Keeper().GetBridgeTokenDenom(suite.Ctx, tokenContract))
 
-	suite.EqualValues(bridgeToken, suite.Keeper().GetDenomBridgeToken(suite.ctx, denom))
+	suite.EqualValues(bridgeToken, suite.Keeper().GetDenomBridgeToken(suite.Ctx, denom))
 
-	suite.Keeper().IterateBridgeTokenToDenom(suite.ctx, func(bt *types.BridgeToken) bool {
+	suite.Keeper().IterateBridgeTokenToDenom(suite.Ctx, func(bt *types.BridgeToken) bool {
 		suite.Equal(bt.Token, tokenContract)
 		suite.Equal(bt.Denom, denom)
 		return false

--- a/x/crosschain/keeper/oracle_set_test.go
+++ b/x/crosschain/keeper/oracle_set_test.go
@@ -41,7 +41,7 @@ func (suite *KeeperTestSuite) TestLastPendingOracleSetRequestByAddr() {
 	}
 
 	for i := 1; i <= 3; i++ {
-		suite.Keeper().StoreOracleSet(suite.ctx, &types.OracleSet{
+		suite.Keeper().StoreOracleSet(suite.Ctx, &types.OracleSet{
 			Nonce: uint64(i),
 			Members: types.BridgeValidators{{
 				Power:           uint64(i),
@@ -51,7 +51,7 @@ func (suite *KeeperTestSuite) TestLastPendingOracleSetRequestByAddr() {
 		})
 	}
 
-	wrapSDKContext := suite.ctx
+	wrapSDKContext := suite.Ctx
 	for _, testCase := range testCases {
 		oracle := types.Oracle{
 			OracleAddress:  testCase.OracleAddress.String(),
@@ -59,8 +59,8 @@ func (suite *KeeperTestSuite) TestLastPendingOracleSetRequestByAddr() {
 			StartHeight:    testCase.StartHeight,
 		}
 		// save oracle
-		suite.Keeper().SetOracle(suite.ctx, oracle)
-		suite.Keeper().SetOracleAddrByBridgerAddr(suite.ctx, testCase.BridgerAddress, oracle.GetOracle())
+		suite.Keeper().SetOracle(suite.Ctx, oracle)
+		suite.Keeper().SetOracleAddrByBridgerAddr(suite.Ctx, testCase.BridgerAddress, oracle.GetOracle())
 
 		response, err := suite.QueryClient().LastPendingOracleSetRequestByAddr(wrapSDKContext,
 			&types.QueryLastPendingOracleSetRequestByAddrRequest{
@@ -75,7 +75,7 @@ func (suite *KeeperTestSuite) TestGetUnSlashedOracleSets() {
 	height := 100
 	index := 10
 	for i := 1; i <= index; i++ {
-		suite.Keeper().StoreOracleSet(suite.ctx, &types.OracleSet{
+		suite.Keeper().StoreOracleSet(suite.Ctx, &types.OracleSet{
 			Nonce: uint64(i),
 			Members: types.BridgeValidators{{
 				Power:           tmrand.Uint64(),
@@ -84,16 +84,16 @@ func (suite *KeeperTestSuite) TestGetUnSlashedOracleSets() {
 			Height: uint64(height + i),
 		})
 	}
-	suite.Equal(uint64(0), suite.Keeper().GetLastSlashedOracleSetNonce(suite.ctx))
+	suite.Equal(uint64(0), suite.Keeper().GetLastSlashedOracleSetNonce(suite.Ctx))
 
-	sets := suite.Keeper().GetUnSlashedOracleSets(suite.ctx, uint64(height+index))
+	sets := suite.Keeper().GetUnSlashedOracleSets(suite.Ctx, uint64(height+index))
 	suite.Require().EqualValues(index-1, sets.Len())
 
-	suite.Keeper().SetLastSlashedOracleSetNonce(suite.ctx, 1)
-	sets = suite.Keeper().GetUnSlashedOracleSets(suite.ctx, uint64(height+index))
+	suite.Keeper().SetLastSlashedOracleSetNonce(suite.Ctx, 1)
+	sets = suite.Keeper().GetUnSlashedOracleSets(suite.Ctx, uint64(height+index))
 	suite.Require().EqualValues(index-2, sets.Len())
 
-	sets = suite.Keeper().GetUnSlashedOracleSets(suite.ctx, uint64(height+index+1))
+	sets = suite.Keeper().GetUnSlashedOracleSets(suite.Ctx, uint64(height+index+1))
 	suite.Require().EqualValues(index-1, sets.Len())
 }
 
@@ -101,7 +101,7 @@ func (suite *KeeperTestSuite) TestKeeper_IterateOracleSetConfirmByNonce() {
 	index := tmrand.Intn(20) + 1
 	for i := uint64(1); i <= uint64(index); i++ {
 		for _, oracle := range suite.oracleAddrs {
-			suite.Keeper().SetOracleSetConfirm(suite.ctx, oracle,
+			suite.Keeper().SetOracleSetConfirm(suite.Ctx, oracle,
 				&types.MsgOracleSetConfirm{
 					Nonce:           i,
 					BridgerAddress:  helpers.GenAccAddress().String(),
@@ -115,7 +115,7 @@ func (suite *KeeperTestSuite) TestKeeper_IterateOracleSetConfirmByNonce() {
 
 	index = tmrand.Intn(index) + 1
 	var confirms []*types.MsgOracleSetConfirm
-	suite.Keeper().IterateOracleSetConfirmByNonce(suite.ctx, uint64(index), func(confirm *types.MsgOracleSetConfirm) bool {
+	suite.Keeper().IterateOracleSetConfirmByNonce(suite.Ctx, uint64(index), func(confirm *types.MsgOracleSetConfirm) bool {
 		confirms = append(confirms, confirm)
 		return false
 	})
@@ -134,13 +134,13 @@ func (suite *KeeperTestSuite) TestKeeper_DeleteOracleSetConfirm() {
 	oracleSet := &types.OracleSet{
 		Nonce:   1,
 		Members: member,
-		Height:  uint64(suite.ctx.BlockHeight()),
+		Height:  uint64(suite.Ctx.BlockHeight()),
 	}
-	suite.Keeper().StoreOracleSet(suite.ctx, oracleSet)
+	suite.Keeper().StoreOracleSet(suite.Ctx, oracleSet)
 
 	for i, external := range suite.externalPris {
 		externalAddress, signature := suite.SignOracleSetConfirm(external, oracleSet)
-		suite.Keeper().SetOracleSetConfirm(suite.ctx, suite.oracleAddrs[i],
+		suite.Keeper().SetOracleSetConfirm(suite.Ctx, suite.oracleAddrs[i],
 			&types.MsgOracleSetConfirm{
 				Nonce:           oracleSet.Nonce,
 				BridgerAddress:  suite.bridgerAddrs[i].String(),
@@ -150,24 +150,24 @@ func (suite *KeeperTestSuite) TestKeeper_DeleteOracleSetConfirm() {
 			},
 		)
 	}
-	suite.Keeper().SetLastObservedOracleSet(suite.ctx,
+	suite.Keeper().SetLastObservedOracleSet(suite.Ctx,
 		&types.OracleSet{
 			Nonce: oracleSet.Nonce + 1,
 		},
 	)
 
-	params := suite.Keeper().GetParams(suite.ctx)
+	params := suite.Keeper().GetParams(suite.Ctx)
 	params.SignedWindow = 10
-	err := suite.Keeper().SetParams(suite.ctx, &params)
+	err := suite.Keeper().SetParams(suite.Ctx, &params)
 	suite.Require().NoError(err)
 	suite.Commit()
 	for _, oracle := range suite.oracleAddrs {
-		suite.NotNil(suite.Keeper().GetOracleSetConfirm(suite.ctx, oracleSet.Nonce, oracle))
+		suite.NotNil(suite.Keeper().GetOracleSetConfirm(suite.Ctx, oracleSet.Nonce, oracle))
 	}
 
 	suite.Commit(int64(params.SignedWindow + 1))
 	for _, oracle := range suite.oracleAddrs {
-		suite.Nil(suite.Keeper().GetOracleSetConfirm(suite.ctx, oracleSet.Nonce, oracle))
+		suite.Nil(suite.Keeper().GetOracleSetConfirm(suite.Ctx, oracleSet.Nonce, oracle))
 	}
 }
 
@@ -180,7 +180,7 @@ func (suite *KeeperTestSuite) TestKeeper_IterateOracleSet() {
 		})
 	}
 	for i := 1; i <= 10; i++ {
-		suite.Keeper().StoreOracleSet(suite.ctx, &types.OracleSet{
+		suite.Keeper().StoreOracleSet(suite.Ctx, &types.OracleSet{
 			Nonce:   uint64(i),
 			Members: member,
 			Height:  uint64(i + 100),
@@ -188,7 +188,7 @@ func (suite *KeeperTestSuite) TestKeeper_IterateOracleSet() {
 	}
 	i := uint64(0)
 	oracleSets := types.OracleSets{}
-	suite.Keeper().IterateOracleSetByNonce(suite.ctx, 0, func(oracleSet *types.OracleSet) bool {
+	suite.Keeper().IterateOracleSetByNonce(suite.Ctx, 0, func(oracleSet *types.OracleSet) bool {
 		i = i + 1
 		suite.Equal(i, oracleSet.Nonce)
 		oracleSets = append(oracleSets, oracleSet)
@@ -197,26 +197,26 @@ func (suite *KeeperTestSuite) TestKeeper_IterateOracleSet() {
 	suite.Equal(len(oracleSets), 10)
 
 	oracleSets = types.OracleSets{}
-	suite.Keeper().IterateOracleSetByNonce(suite.ctx, 1, func(oracleSet *types.OracleSet) bool {
+	suite.Keeper().IterateOracleSetByNonce(suite.Ctx, 1, func(oracleSet *types.OracleSet) bool {
 		oracleSets = append(oracleSets, oracleSet)
 		return false
 	})
 	suite.Equal(len(oracleSets), 10)
 
 	oracleSets = types.OracleSets{}
-	suite.Keeper().IterateOracleSetByNonce(suite.ctx, 2, func(oracleSet *types.OracleSet) bool {
+	suite.Keeper().IterateOracleSetByNonce(suite.Ctx, 2, func(oracleSet *types.OracleSet) bool {
 		oracleSets = append(oracleSets, oracleSet)
 		return false
 	})
 	suite.Equal(len(oracleSets), 9)
 
-	suite.Keeper().IterateOracleSets(suite.ctx, true, func(oracleSet *types.OracleSet) bool {
+	suite.Keeper().IterateOracleSets(suite.Ctx, true, func(oracleSet *types.OracleSet) bool {
 		suite.Equal(i, oracleSet.Nonce, oracleSet.Nonce)
 		i = i - 1
 		return false
 	})
 
-	suite.Keeper().IterateOracleSets(suite.ctx, false, func(oracleSet *types.OracleSet) bool {
+	suite.Keeper().IterateOracleSets(suite.Ctx, false, func(oracleSet *types.OracleSet) bool {
 		i = i + 1
 		suite.Equal(i, oracleSet.Nonce)
 		return false

--- a/x/crosschain/keeper/oracle_test.go
+++ b/x/crosschain/keeper/oracle_test.go
@@ -2,11 +2,11 @@ package keeper_test
 
 func (suite *KeeperTestSuite) TestOracleAndBridger() {
 	for _, oracle := range suite.oracleAddrs {
-		suite.Require().True(suite.Keeper().IsProposalOracle(suite.ctx, oracle.String()))
+		suite.Require().True(suite.Keeper().IsProposalOracle(suite.Ctx, oracle.String()))
 	}
 
 	for _, bridger := range suite.bridgerAddrs {
-		oracle, found := suite.Keeper().GetOracleAddrByBridgerAddr(suite.ctx, bridger)
+		oracle, found := suite.Keeper().GetOracleAddrByBridgerAddr(suite.Ctx, bridger)
 		suite.Require().False(found)
 		suite.Require().Equal("", oracle.String())
 	}

--- a/x/crosschain/keeper/outgoing_pool_test.go
+++ b/x/crosschain/keeper/outgoing_pool_test.go
@@ -15,61 +15,61 @@ func (suite *KeeperTestSuite) TestKeeper_OutgoingPool() {
 	sender := helpers.GenHexAddress().Bytes()
 	bridgeToken := helpers.GenHexAddress().Hex()
 	denom := types.NewBridgeDenom(suite.chainName, bridgeToken)
-	suite.Equal(sdk.NewCoin(denom, sdkmath.ZeroInt()), suite.app.BankKeeper.GetSupply(suite.ctx, denom))
+	suite.Equal(sdk.NewCoin(denom, sdkmath.ZeroInt()), suite.App.BankKeeper.GetSupply(suite.Ctx, denom))
 
 	sendAmount := sdk.NewCoin(denom, sdkmath.NewInt(int64(tmrand.Uint32()*2)))
-	err := suite.app.BankKeeper.MintCoins(suite.ctx, suite.chainName, sdk.NewCoins(sendAmount))
+	err := suite.App.BankKeeper.MintCoins(suite.Ctx, suite.chainName, sdk.NewCoins(sendAmount))
 	suite.NoError(err)
-	err = suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, suite.chainName, sender, sdk.NewCoins(sendAmount))
+	err = suite.App.BankKeeper.SendCoinsFromModuleToAccount(suite.Ctx, suite.chainName, sender, sdk.NewCoins(sendAmount))
 	suite.NoError(err)
-	suite.Equal(sendAmount, suite.app.BankKeeper.GetSupply(suite.ctx, denom))
+	suite.Equal(sendAmount, suite.App.BankKeeper.GetSupply(suite.Ctx, denom))
 
-	suite.Keeper().AddBridgeToken(suite.ctx, bridgeToken, denom)
+	suite.Keeper().AddBridgeToken(suite.Ctx, bridgeToken, denom)
 
-	suite.Equal(suite.app.BankKeeper.GetAllBalances(suite.ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
+	suite.Equal(suite.App.BankKeeper.GetAllBalances(suite.Ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
 	receiver := helpers.GenHexAddress().Hex()
 	amount := sdk.NewCoin(denom, sendAmount.Amount.QuoRaw(2))
-	txId, err := suite.Keeper().AddToOutgoingPool(suite.ctx, sender, receiver, amount, amount)
+	txId, err := suite.Keeper().AddToOutgoingPool(suite.Ctx, sender, receiver, amount, amount)
 	suite.NoError(err)
-	suite.Equal(suite.app.BankKeeper.GetAllBalances(suite.ctx, sender).AmountOf(denom).String(), sdkmath.NewInt(0).String())
+	suite.Equal(suite.App.BankKeeper.GetAllBalances(suite.Ctx, sender).AmountOf(denom).String(), sdkmath.NewInt(0).String())
 
-	suite.Equal(sdk.NewCoin(denom, sdkmath.ZeroInt()), suite.app.BankKeeper.GetSupply(suite.ctx, denom))
+	suite.Equal(sdk.NewCoin(denom, sdkmath.ZeroInt()), suite.App.BankKeeper.GetSupply(suite.Ctx, denom))
 
-	_, err = suite.Keeper().RemoveFromOutgoingPoolAndRefund(suite.ctx, txId, sender)
+	_, err = suite.Keeper().RemoveFromOutgoingPoolAndRefund(suite.Ctx, txId, sender)
 	suite.NoError(err)
-	suite.Equal(suite.app.BankKeeper.GetAllBalances(suite.ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
+	suite.Equal(suite.App.BankKeeper.GetAllBalances(suite.Ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
 
-	suite.Equal(sendAmount, suite.app.BankKeeper.GetSupply(suite.ctx, denom))
+	suite.Equal(sendAmount, suite.App.BankKeeper.GetSupply(suite.Ctx, denom))
 }
 
 func (suite *KeeperTestSuite) TestKeeper_OutgoingPool2() {
 	sender := helpers.GenHexAddress().Bytes()
 	bridgeToken := helpers.GenHexAddress().Hex()
 	denom := fxtypes.DefaultDenom
-	supply := suite.app.BankKeeper.GetSupply(suite.ctx, denom)
+	supply := suite.App.BankKeeper.GetSupply(suite.Ctx, denom)
 
 	sendAmount := sdk.NewCoin(denom, sdkmath.NewInt(int64(tmrand.Uint32()*2)))
-	err := suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, suite.chainName, sender, sdk.NewCoins(sendAmount))
+	err := suite.App.BankKeeper.SendCoinsFromModuleToAccount(suite.Ctx, suite.chainName, sender, sdk.NewCoins(sendAmount))
 	if suite.chainName != ethtypes.ModuleName {
 		suite.Error(err)
 		return
 	}
 	suite.NoError(err)
 
-	suite.Keeper().AddBridgeToken(suite.ctx, bridgeToken, denom)
+	suite.Keeper().AddBridgeToken(suite.Ctx, bridgeToken, denom)
 
-	suite.Equal(suite.app.BankKeeper.GetAllBalances(suite.ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
+	suite.Equal(suite.App.BankKeeper.GetAllBalances(suite.Ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
 	receiver := helpers.GenHexAddress().Hex()
 	amount := sdk.NewCoin(denom, sendAmount.Amount.QuoRaw(2))
-	txId, err := suite.Keeper().AddToOutgoingPool(suite.ctx, sender, receiver, amount, amount)
+	txId, err := suite.Keeper().AddToOutgoingPool(suite.Ctx, sender, receiver, amount, amount)
 	suite.NoError(err)
-	suite.Equal(suite.app.BankKeeper.GetAllBalances(suite.ctx, sender).AmountOf(denom).String(), sdkmath.NewInt(0).String())
+	suite.Equal(suite.App.BankKeeper.GetAllBalances(suite.Ctx, sender).AmountOf(denom).String(), sdkmath.NewInt(0).String())
 
-	suite.Equal(supply, suite.app.BankKeeper.GetSupply(suite.ctx, denom))
+	suite.Equal(supply, suite.App.BankKeeper.GetSupply(suite.Ctx, denom))
 
-	_, err = suite.Keeper().RemoveFromOutgoingPoolAndRefund(suite.ctx, txId, sender)
+	_, err = suite.Keeper().RemoveFromOutgoingPoolAndRefund(suite.Ctx, txId, sender)
 	suite.NoError(err)
-	suite.Equal(suite.app.BankKeeper.GetAllBalances(suite.ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
+	suite.Equal(suite.App.BankKeeper.GetAllBalances(suite.Ctx, sender).AmountOf(denom).String(), sendAmount.Amount.String())
 
-	suite.Equal(supply, suite.app.BankKeeper.GetSupply(suite.ctx, denom))
+	suite.Equal(supply, suite.App.BankKeeper.GetSupply(suite.Ctx, denom))
 }

--- a/x/crosschain/keeper/params_test.go
+++ b/x/crosschain/keeper/params_test.go
@@ -188,8 +188,8 @@ func (suite *KeeperTestSuite) TestParams() {
 	}
 	for _, tc := range testCases {
 		suite.Run(tc.name, func() {
-			expected := suite.Keeper().GetParams(suite.ctx)
-			err := suite.Keeper().SetParams(suite.ctx, tc.input)
+			expected := suite.Keeper().GetParams(suite.Ctx)
+			err := suite.Keeper().SetParams(suite.Ctx, tc.input)
 			if tc.expectErr {
 				suite.Require().Error(err)
 				suite.Require().Contains(err.Error(), tc.expErrMsg)
@@ -197,7 +197,7 @@ func (suite *KeeperTestSuite) TestParams() {
 				expected = *tc.input
 				suite.Require().NoError(err)
 			}
-			params := suite.Keeper().GetParams(suite.ctx)
+			params := suite.Keeper().GetParams(suite.Ctx)
 			suite.Require().Equal(expected, params)
 		})
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Removed the ability to programmatically mint blocks in tests, impacting block minting functionality.
  
- **Refactor**
	- Standardized context variable naming from `ctx` to `Ctx` across multiple test files for consistency and clarity.
	- Updated the `KeeperTestSuite` structure to utilize a `BaseSuite`, enhancing code maintainability.

- **Bug Fixes**
	- Improved efficiency in initializing validator addresses within the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->