### PR TITLE
chore: relink interchain token

### DIFF
--- a/solidity/.gitignore
+++ b/solidity/.gitignore
@@ -11,3 +11,4 @@ contracts/package.json
 typechain-types
 artifacts
 *.log
+ignition/deployments

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -36,7 +36,7 @@ const config: HardhatUserConfig = {
     },
     sepolia: {
       url: `${
-        process.env.SEPOLIA_URL || "https://rpc.thanos-sepolia.tokamak.network"
+        process.env.SEPOLIA_URL || "https://eth-sepolia.public.blastapi.io"
       }`,
       chainId: 11155111,
       accounts: process.env.RAW_PRIVATE_KEY
@@ -56,6 +56,9 @@ const config: HardhatUserConfig = {
     baseSepolia: {
       url: `${process.env.BASE_URL || "https://sepolia.base.org"}`,
       chainId: 84532,
+      accounts: process.env.RAW_PRIVATE_KEY
+        ? [process.env.RAW_PRIVATE_KEY]
+        : undefined,
     },
     polygonAmoy: {
       url: `${
@@ -100,6 +103,14 @@ const config: HardhatUserConfig = {
         : undefined,
     },
   },
+  ignition: {
+    strategyConfig: {
+      create2: {
+        // To learn more about salts, see the CreateX documentation
+        salt: "0x355549848424f226744f74f3f661da1a6eca0df8de368542112014fd1e2a7748",
+      },
+    },
+  },
   solidity: {
     compilers: [
       {
@@ -141,15 +152,7 @@ const config: HardhatUserConfig = {
     ],
   },
   etherscan: {
-    apiKey: {
-      ethereum: `${process.env.ETHERSCAN_API_KEY}`,
-      base: `${process.env.ETHERSCAN_API_KEY}`,
-      bsc: `${process.env.ETHERSCAN_API_KEY}`,
-      sepolia: `${process.env.ETHERSCAN_API_KEY}`,
-      arbitrumSepolia: `${process.env.ETHERSCAN_API_KEY}`,
-      optimisticSepolia: `${process.env.ETHERSCAN_API_KEY}`,
-      baseSepolia: `${process.env.ETHERSCAN_API_KEY}`,
-    },
+    apiKey: `${process.env.ETHERSCAN_API_KEY}`,
     customChains: [
       {
         network: "ethereum",

--- a/solidity/ignition/modules/deploy_pundiai_interchain_token.ts
+++ b/solidity/ignition/modules/deploy_pundiai_interchain_token.ts
@@ -7,16 +7,16 @@ const InterchainTokenModule = buildModule("InterchainTokenModule", (m) => {
     [],
     { id: "PundiAIFXInterchainToken" }
   );
-  // const initializeData = m.encodeFunctionCall(
-  //   pundiAIFXInterchainTokenLogic,
-  //   "initialize",
-  //   []
-  // );
-  // const pundiAIFXInterchainTokenProxy = m.contract(
-  //   "ERC1967Proxy",
-  //   [pundiAIFXInterchainTokenLogic, initializeData],
-  //   { id: "PundiAIFXInterchainTokenProxy" }
-  // );
+  const initializeData = m.encodeFunctionCall(
+    pundiAIFXInterchainTokenLogic,
+    "initialize",
+    []
+  );
+  const pundiAIFXInterchainTokenProxy = m.contract(
+    "ERC1967Proxy",
+    [pundiAIFXInterchainTokenLogic, initializeData],
+    { id: "PundiAIFXInterchainTokenProxy" }
+  );
   return { pundiAIFXInterchainTokenLogic };
 });
 

--- a/solidity/scripts/02_register_custom_token.ts
+++ b/solidity/scripts/02_register_custom_token.ts
@@ -1,21 +1,25 @@
 import { ethers } from "ethers";
 import {
-  sourceChainTokenAddress,
+  getSigner,
   interchainTokenFactoryContractABI,
   interchainTokenFactoryContractAddress,
-  tokenManagerTypeMintBurn,
-  salt,
-  txFee,
-  getSigner,
-  waitForTransaction,
   interchainTokenServiceContractAddress,
   requireSourceChainTokenAddress,
+  salt,
+  sourceChainTokenAddress,
+  tokenManagerType,
+  txFee,
+  waitForTransaction,
 } from "./common";
 
 async function main() {
   requireSourceChainTokenAddress();
+  if (tokenManagerType === "") {
+    throw new Error("TOKEN_MANAGER_TYPE environment variable is required");
+  }
 
   const signer = await getSigner();
+  let signerAddr = await signer.getAddress();
 
   const interchainTokenFactoryContract = new ethers.Contract(
     interchainTokenFactoryContractAddress,
@@ -23,11 +27,10 @@ async function main() {
     signer
   );
 
-  let sigerAddr = await signer.getAddress();
   console.log("registerCustomToken tx params:", {
     sourceChainTokenAddress,
-    tokenManagerTypeMintBurn,
-    sigerAddr,
+    tokenManagerType,
+    signerAddr,
     salt,
     txFee,
     value: ethers.parseEther(txFee),
@@ -36,8 +39,8 @@ async function main() {
     await interchainTokenFactoryContract.registerCustomToken(
       salt,
       sourceChainTokenAddress,
-      tokenManagerTypeMintBurn,
-      sigerAddr,
+      tokenManagerType,
+      signerAddr,
       { value: ethers.parseEther(txFee) }
     );
   console.log("registerCustomToken tx:", registerCustomTokenTx.hash);

--- a/solidity/scripts/03_link_token.ts
+++ b/solidity/scripts/03_link_token.ts
@@ -4,7 +4,7 @@ import {
   destinationChainName,
   interchainTokenFactoryContractABI,
   interchainTokenFactoryContractAddress,
-  tokenManagerTypeLockUnLock,
+  tokenManagerType,
   salt,
   txFee,
   getSigner,
@@ -12,7 +12,19 @@ import {
 } from "./common";
 
 async function main() {
+  if (destinationChainName === "") {
+    throw new Error("DESTINATION_CHAIN_NAME environment variable is required");
+  }
+  if (destinationChainTokenAddress === "") {
+    throw new Error(
+      "DESTINATION_CHAIN_TOKEN_ADDRESS environment variable is required"
+    );
+  }
+  if (tokenManagerType === "") {
+    throw new Error("TOKEN_MANAGER_TYPE environment variable is required");
+  }
   const signer = await getSigner();
+  let signerAddr = await signer.getAddress();
 
   const interchainTokenFactoryContract = new ethers.Contract(
     interchainTokenFactoryContractAddress,
@@ -20,11 +32,10 @@ async function main() {
     signer
   );
 
-  let signerAddr = await signer.getAddress();
   console.log("linkToken tx params:", {
     destinationChainTokenAddress,
     destinationChainName,
-    tokenManagerTypeLockUnLock,
+    tokenManagerType,
     signerAddr,
     salt,
     txFee,
@@ -34,7 +45,7 @@ async function main() {
     salt,
     destinationChainName,
     destinationChainTokenAddress,
-    tokenManagerTypeLockUnLock,
+    tokenManagerType,
     signerAddr,
     ethers.parseEther(txFee),
     { value: ethers.parseEther(txFee) }

--- a/solidity/scripts/06_set_flow_limit.ts
+++ b/solidity/scripts/06_set_flow_limit.ts
@@ -6,12 +6,13 @@ import {
   getSigner,
   waitForTransaction,
   requireSourceChainTokenAddress,
-  requireInterchainTokenManagerAddress,
 } from "./common";
 
 async function main() {
   requireSourceChainTokenAddress();
-  requireInterchainTokenManagerAddress();
+  if (interchainTokenManagerAddress === "") {
+    throw new Error("TOKEN_MANAGER_ADDRESS environment variable is required");
+  }
 
   const signer = await getSigner();
 

--- a/solidity/scripts/07_add_native_gas.ts
+++ b/solidity/scripts/07_add_native_gas.ts
@@ -17,6 +17,7 @@ async function main() {
   }
 
   const signer = await getSigner();
+  let signerAddr = await signer.getAddress();
 
   const gasServiceContract = new ethers.Contract(
     gasServiceContractAddress,
@@ -24,7 +25,6 @@ async function main() {
     signer
   );
 
-  let signerAddr = await signer.getAddress();
   console.log("addNativeGas tx params:", {
     addNativeGas: ethers.parseEther(txFee),
     txHash,

--- a/solidity/scripts/common.ts
+++ b/solidity/scripts/common.ts
@@ -2,20 +2,14 @@
 import hre from "hardhat";
 import { Signer } from "ethers";
 
-// ref: https://docs.axelar.dev/resources/contract-addresses/testnet/
-// ref: https://testnet.interchain.axelar.dev/ethereum-sepolia/0xebCb46E14bCd0F8639A24b32fBC6Db6935F046Fe
-
-const sourceChainName = process.env.SOURCE_CHAIN_NAME || "bsc";
-
 export const interchainTokenServiceContractABI =
   '[{"inputs":[{"internalType":"address","name":"tokenAddress","type":"address"},{"internalType":"uint256","name":"gasValue","type":"uint256"}],"name":"registerTokenMetadata","outputs":[],"stateMutability":"payable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"tokenId","type":"bytes32"},{"internalType":"string","name":"destinationChain","type":"string"},{"internalType":"bytes","name":"destinationAddress","type":"bytes"},{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"bytes","name":"metadata","type":"bytes"},{"internalType":"uint256","name":"gasValue","type":"uint256"}],"name":"interchainTransfer","outputs":[],"stateMutability":"payable","type":"function"}]';
 export const interchainTokenFactoryContractABI =
   '[{"inputs":[{"internalType":"bytes32","name":"salt","type":"bytes32"},{"internalType":"address","name":"tokenAddress","type":"address"},{"internalType":"enum ITokenManagerType.TokenManagerType","name":"tokenManagerType","type":"uint8"},{"internalType":"address","name":"operator","type":"address"}],"name":"registerCustomToken","outputs":[{"internalType":"bytes32","name":"tokenId","type":"bytes32"}],"stateMutability":"payable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"salt","type":"bytes32"},{"internalType":"string","name":"destinationChain","type":"string"},{"internalType":"bytes","name":"destinationTokenAddress","type":"bytes"},{"internalType":"enum ITokenManagerType.TokenManagerType","name":"tokenManagerType","type":"uint8"},{"internalType":"bytes","name":"linkParams","type":"bytes"},{"internalType":"uint256","name":"gasValue","type":"uint256"}],"name":"linkToken","outputs":[{"internalType":"bytes32","name":"tokenId","type":"bytes32"}],"stateMutability":"payable","type":"function"},{"inputs":[{"internalType":"address","name":"deployer","type":"address"},{"internalType":"bytes32","name":"salt","type":"bytes32"}],"name":"linkedTokenId","outputs":[{"internalType":"bytes32","name":"tokenId","type":"bytes32"}],"stateMutability":"view","type":"function"}]';
 export const interchainTokenABI =
-  '[{"inputs":[{"internalType":"bytes32","name":"salt","type":"bytes32"}],"name":"setItsSalt","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"its","type":"address"}],"name":"setInterchainTokenService","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"interchainTokenService","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"interchainTokenId","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"grantRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"hasRole","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"grantRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"revokeRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"address","name":"spender","type":"address"}],"name":"allowance","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"approve","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]';
+  '[{"inputs":[],"name":"interchainTokenService","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"interchainTokenId","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"string","name":"destinationChain","type":"string"},{"internalType":"bytes","name":"recipient","type":"bytes"},{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"bytes","name":"metadata","type":"bytes"}],"name":"interchainTransfer","outputs":[],"stateMutability":"payable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"tokenId","type":"bytes32"}],"name":"setTokenId","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"its","type":"address"}],"name":"setInterchainTokenService","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"interchainTokenService","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"interchainTokenId","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"grantRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"hasRole","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"grantRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"revokeRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"address","name":"spender","type":"address"}],"name":"allowance","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"approve","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"}]';
 export const gasServiceABI =
   '[{"inputs":[{"internalType":"bytes32","name":"txHash","type":"bytes32"},{"internalType":"uint256","name":"logIndex","type":"uint256"},{"internalType":"address","name":"refundAddress","type":"address"}],"name":"addNativeGas","outputs":[],"stateMutability":"payable","type":"function"}]';
-
 export const interchainTokenManagerABI =
   '[{"inputs":[],"name":"getImplementationTypeAndTokenAddress","outputs":[{"internalType":"uint256","name":"","type":"uint256"},{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"flowLimit","outputs":[{"internalType":"uint256","name":"flowLimit_","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"flowLimit_","type":"uint256"}],"name":"setFlowLimit","outputs":[],"stateMutability":"nonpayable","type":"function"}]';
 
@@ -28,17 +22,15 @@ export const interchainTokenFactoryContractAddress =
 export const gasServiceContractAddress =
   "0x2d5d7d31F671F86C782533cc367F14109a082712";
 
+// openssl rand -hex 32
+export const salt =
+  "0xc144c0dcfd41bcf51f2ee6d6cea553d8bf07f31c330cf5b698b0dee6bdb41308";
+
+const sourceChainName = process.env.SOURCE_CHAIN_NAME || "";
+export const destinationChainName = process.env.DESTINATION_CHAIN_NAME || "";
+
 export const destinationChainTokenAddress =
-  hre.network.name == sourceChainName
-    ? "0x075F23b9CdfCE2cC0cA466F4eE6cb4bD29d83bef" // ethereum mainnet pundiaifx
-    : "0xebCb46E14bCd0F8639A24b32fBC6Db6935F046Fe"; // ethereum sepolia pundiaifx
-
-export let destinationChainName = "";
-
-if (sourceChainName != "ethereum") {
-  destinationChainName =
-    hre.network.name == sourceChainName ? "Ethereum" : "ethereum-sepolia";
-}
+  process.env.DESTINATION_CHAIN_TOKEN_ADDRESS || "";
 
 export const sourceChainTokenAddress: string =
   process.env.SOURCE_CHAIN_TOKEN_ADDRESS || "";
@@ -46,38 +38,33 @@ export const sourceChainTokenAddress: string =
 export const interchainTokenManagerAddress: string =
   process.env.TOKEN_MANAGER_ADDRESS || "";
 
-// import crypto from "crypto";
-// console.log("nwe salt", "0x" + crypto.randomBytes(32).toString("hex"))
-export const salt =
-  hre.network.name == sourceChainName
-    ? "0xc144c0dcfd41bcf51f2ee6d6cea553d8bf07f31c330cf5b698b0dee6bdb41308"
-    : "0x2b1f7645a5ea54f9c9281d2a71038e31b50422570195c08ce3124929c1a709ef";
-
-export const tokenManagerTypeMintBurn = 4;
-export const tokenManagerTypeLockUnLock = 2;
+export const tokenManagerType = process.env.TOKEN_MANAGER_TYPE || "";
 
 export const txFee = process.env.TX_FEE ? process.env.TX_FEE : "0.002";
 
-console.log(
-  "interchainTokenServiceContractAddress:",
-  interchainTokenServiceContractAddress
-);
-console.log(
-  "interchainTokenFactoryContractAddress:",
-  interchainTokenFactoryContractAddress
-);
+let tokenManagerToString: string = "";
+if (tokenManagerType == "1") {
+  tokenManagerToString = "Mint/BurnFrom";
+} else if (tokenManagerType == "2") {
+  tokenManagerToString = "Lock/Unlock";
+} else if (tokenManagerType == "3") {
+  tokenManagerToString = "Lock/UnlockFee";
+} else if (tokenManagerType == "4") {
+  tokenManagerToString = "Mint/Burn";
+}
 
 console.log({
-  sourceChainName,
   network: hre.network.name,
-  destinationChainTokenAddress,
-  destinationChainName,
+  sourceChainName,
   sourceChainTokenAddress,
+  destinationChainName,
+  destinationChainTokenAddress,
+  interchainTokenServiceContractAddress,
+  interchainTokenFactoryContractAddress,
   interchainTokenManagerAddress,
   gasServiceContractAddress,
   salt,
-  tokenManagerTypeMintBurn,
-  tokenManagerTypeLockUnLock,
+  tokenManagerToString,
   txFee,
 });
 
@@ -116,11 +103,5 @@ export function requireSourceChainTokenAddress() {
     throw new Error(
       "SOURCE_CHAIN_TOKEN_ADDRESS environment variable is required"
     );
-  }
-}
-
-export function requireInterchainTokenManagerAddress() {
-  if (interchainTokenManagerAddress === "") {
-    throw new Error("TOKEN_MANAGER_ADDRESS environment variable is required");
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled proxy-based initialization for the interchain token deployment.
  - Added Create2 salt support in deployment configuration.
  - Introduced environment-driven configuration for chain names, token addresses, and manager type.
  - Added a dedicated interchain transfer function and dual transfer path.

- Bug Fixes
  - Corrected signer address handling to avoid undefined/typo issues.

- Refactor
  - Standardized token manager type naming and logging.
  - Simplified Etherscan API key configuration.
  - Updated default RPC endpoint for Sepolia.

- Chores
  - Ignored deployment artifacts in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->