### PR TITLE
docs: document end of maintenance and add validator exit guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 **Pundi AIFX** is a blockchain built using Cosmos SDK and Cometbft.
 
+## Maintenance status (read this first)
+
+**Official maintenance of this repository and the reference `fxcored` binaries ended on March 1, 2026.** There will be no guaranteed security fixes, upgrade coordination, or release support from the core team after that date. A small number of validators may still be online; if you operate one, treat the network as **community-run / at your own risk**.
+
+For a step-by-step **validator exit** walkthrough (unbonding, keys, and shutting down the node), see [docs/validator-exit-guide.md](docs/validator-exit-guide.md).
+
+### If you still run a validator — quick checklist
+
+1. **Decide whether to keep operating.** Without official maintenance, you are responsible for incident response, chain halts, and any emergency patches yourself (or via a community fork).
+2. **Plan key and funds safety.** Ensure operator keys, consensus keys, and key backups are stored offline and access-controlled. If you stop validating, follow the normal Cosmos SDK flow for **unbonding** / **undelegation** and respect unbonding time on **mainnet `fxcore`** or **testnet `dhobyghaut`** as applicable.
+3. **Stop the node cleanly when you exit.** Disable orchestration (systemd, Kubernetes, cosmovisor, etc.), then shut down `fxcored` so the validator does not keep signing while you intend to leave the active set.
+4. **Archive what you need.** Export or retain any accounting, logs, or state snapshots required for your records before decommissioning hardware.
+5. **Use tagged releases only — never `main`.** Historical builds and upgrade heights are described in [Releases](https://github.com/pundiai/fx-core/releases); `main` is not a supported production branch.
+6. **Docs may be stale.** The former documentation site is [Pundi AIFX Docs](https://pundi.gitbook.io); verify any procedure against on-chain parameters and your own node version.
+
 [![Version](https://img.shields.io/github/v/release/pundiai/fx-core.svg)](https://github.com/pundiai/fx-core/releases/latest)
 [![License](https://img.shields.io/github/license/pundiai/fx-core.svg)](https://github.com/pundiai/fx-core/blob/main/LICENSE)
 [![API Reference](https://pkg.go.dev/badge/github.com/pundiai/fx-core.svg)](https://pkg.go.dev/github.com/pundiai/fx-core/v8)

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@
 * [PundiScan](https://pundiscan.io)
 * [Ping.Pub](https://ping.pub/fxcore)
 * [Develop Tools](tools)
+* [Validator exit guide](validator-exit-guide.md)
 
 # Pundi AIFX SDK
 

--- a/docs/validator-exit-guide.md
+++ b/docs/validator-exit-guide.md
@@ -1,0 +1,74 @@
+# Validator exit guide
+
+This guide explains how to exit as a validator on the **Pundi AIFX** chain by unbonding your self-delegation. When a validator's self-delegation falls below the minimum self-delegation threshold, the validator will automatically go offline. **Importantly, the validator will not be penalized** in this process.
+
+---
+
+## Method 1: Via command line
+
+### Step 1: Query self-delegation
+
+Before unbonding, check your current self-delegation. Use your **account address** (the same key you used to self-delegate) and your **validator operator address** (`fxvaloper...`):
+
+```bash
+fxcored query staking delegation [your-account-address] [your-validator-valoper] --node https://fx-json.functionx.io:26657
+```
+
+To list **all** delegations to your validator (including self-delegation):
+
+```bash
+fxcored query staking delegations-to [your-validator-valoper] --node https://fx-json.functionx.io:26657
+```
+
+### Step 2: Query validator information (optional)
+
+To view general validator details:
+
+```bash
+fxcored query staking validator [your-validator-valoper] --node https://fx-json.functionx.io:26657
+```
+
+### Step 3: Unbond (cancel self-delegation)
+
+Execute the unbond transaction:
+
+```bash
+fxcored tx staking unbond [validator-valoper] [amount] --from mywallet --gas auto --gas-adjustment 1.5 --gas-prices 5000000000apundiai --chain-id fxcore --node https://fx-json.functionx.io:26657
+```
+
+Replace:
+
+- `[validator-valoper]` — Your validator operator address (`fxvaloper...`)
+- `[amount]` — Amount to unbond (e.g. `1000000000000000000apundiai`)
+- `mywallet` — Your wallet key name (list keys with `fxcored keys list`)
+
+---
+
+## Method 2: Via block explorer
+
+1. Open the block explorer: [https://pundiscan.io/pundiaifx/validators](https://pundiscan.io/pundiaifx/validators)
+2. Connect your wallet
+3. Click the **Delegate** button
+4. Select the **Unbonding** tab
+5. View your delegation list and select the delegation you wish to unbond
+6. Click the **Undelegate** button
+7. Enter the amount to undelegate
+8. Click **Submit** and wait for the transaction to complete
+
+---
+
+## Shutting down the node
+
+After your validator has left the active set (or you no longer intend to run the binary):
+
+1. Stop process supervision (systemd, cosmovisor, Kubernetes, etc.).
+2. Stop `fxcored` cleanly so it does not keep trying to sign.
+3. Keep a secure backup of keys and any on-disk data you need before decommissioning hardware.
+
+---
+
+## Important notes
+
+- **No penalty**: When your self-delegation drops below the minimum self-delegation threshold, the validator will automatically go offline. You will **not** be slashed or penalized.
+- **Unbonding period**: After unbonding, tokens enter an unbonding period before they become fully transferable. Check the chain parameters for the exact unbonding duration.
+- **Minimum threshold**: Ensure you understand the minimum self-delegation requirement for validators on the network before proceeding.


### PR DESCRIPTION
## Summary

- Add a prominent **Maintenance status** section at the top of the root `README.md` stating that official maintenance ended on **March 1, 2026**, and what that implies for validators (no guaranteed security fixes, upgrades, or release support).
- Add a short **validator checklist** (decision to keep running, keys and unbonding, clean shutdown, archival, releases vs `main`, stale docs).
- Add `docs/validator-exit-guide.md` with CLI and explorer steps to exit via self-delegation unbond, plus a brief **Shutting down the node** section. CLI examples correct the staking query usage (delegation / delegations-to / validator) relative to a prior external gist.
- Link the guide from the README and from `docs/README.md`.

## Notes

- PR description and commit messages are in English only.
- Validators are directed to tagged [Releases](https://github.com/PundiAI/fx-core/releases) for binaries, not `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added maintenance status information stating official support for the repository and reference binaries ended on March 1, 2026.
  * Added comprehensive validator exit guide with step-by-step instructions covering exit decisions, key and fund safety considerations, unbonding and undelegation procedures, node shutdown steps, and important notes about unbonding periods and minimum self-delegation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->